### PR TITLE
fix: remove wildcard patterns from custom domain routes

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -25,7 +25,7 @@ id = "d323a9723d424eed9a8aab2b1b9e15b0"
 command = "npm run build"
 
 [[routes]]
-pattern = "api.mirubato.com/*"
+pattern = "api.mirubato.com"
 custom_domain = true
 
 # Local development configuration (for local dev server)
@@ -114,5 +114,5 @@ id = "d323a9723d424eed9a8aab2b1b9e15b0"
 command = "npm run build"
 
 [[env.production.routes]]
-pattern = "api.mirubato.com/*"
+pattern = "api.mirubato.com"
 custom_domain = true

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -13,11 +13,11 @@ directory = "./dist"
 binding = "ASSETS"
 
 [[routes]]
-pattern = "mirubato.com/*"
+pattern = "mirubato.com"
 custom_domain = true
 
 [[routes]]
-pattern = "www.mirubato.com/*"
+pattern = "www.mirubato.com"
 custom_domain = true
 
 # Local development configuration (for local dev server)


### PR DESCRIPTION
- Remove /* patterns from frontend and backend routes
- Cloudflare Workers don't allow wildcards in custom domain routes
- Fixes production deployment failures on both frontend and backend

The routes now use exact domain matches:
- frontend: mirubato.com, www.mirubato.com
- backend: api.mirubato.com

## Description
Brief description of changes and motivation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Musical Content Review
- [ ] Musical theory accuracy verified
- [ ] Pedagogical approach validated
- [ ] Instrument-specific considerations addressed

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing done

## Accessibility
- [ ] Keyboard navigation tested
- [ ] Screen reader compatibility verified
- [ ] Color contrast requirements met
- [ ] Mobile accessibility validated

## Performance
- [ ] No performance regressions introduced
- [ ] Bundle size impact assessed
- [ ] Audio latency tested
- [ ] Memory usage profiled