### PR TITLE
fix: add contents:write permission for GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
   pull-requests: write


### PR DESCRIPTION
The GitHub Actions workflow was failing with:
'Permission to pezware/mirubato.git denied to github-actions[bot]'

This was because peaceiris/actions-gh-pages@v4 needs contents:write permission to push to the gh-pages branch.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
Brief description of changes and motivation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Musical Content Review
- [ ] Musical theory accuracy verified
- [ ] Pedagogical approach validated
- [ ] Instrument-specific considerations addressed

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing done

## Accessibility
- [ ] Keyboard navigation tested
- [ ] Screen reader compatibility verified
- [ ] Color contrast requirements met
- [ ] Mobile accessibility validated

## Performance
- [ ] No performance regressions introduced
- [ ] Bundle size impact assessed
- [ ] Audio latency tested
- [ ] Memory usage profiled