### PR TITLE
fix: add AudioProvider to App.tsx to fix Practice page error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from './contexts/AuthContext'
+import { AudioProvider } from './contexts/AudioContext'
 import LandingPage from './components/LandingPage'
 import Practice from './pages/Practice'
 import AuthVerify from './pages/AuthVerify'
@@ -11,23 +12,28 @@ function App() {
   return (
     <Router>
       <AuthProvider>
-        <div className="min-h-screen">
-          <Routes>
-            <Route path="/" element={<LandingPage />} />
-            <Route path="/login" element={<div>Login Page (TODO)</div>} />
-            <Route path="/auth/verify" element={<AuthVerify />} />
-            <Route
-              path="/magic-link"
-              element={<div>Magic Link Verification (TODO)</div>}
-            />
-            <Route path="/practice" element={<Practice />} />
-            <Route path="/profile" element={<div>Profile Page (TODO)</div>} />
-            <Route path="/settings" element={<div>Settings Page (TODO)</div>} />
-            <Route path="/debug" element={<Debug />} />
-            <Route path="/docs/*" element={<Docs />} />
-          </Routes>
-          <VersionInfo />
-        </div>
+        <AudioProvider>
+          <div className="min-h-screen">
+            <Routes>
+              <Route path="/" element={<LandingPage />} />
+              <Route path="/login" element={<div>Login Page (TODO)</div>} />
+              <Route path="/auth/verify" element={<AuthVerify />} />
+              <Route
+                path="/magic-link"
+                element={<div>Magic Link Verification (TODO)</div>}
+              />
+              <Route path="/practice" element={<Practice />} />
+              <Route path="/profile" element={<div>Profile Page (TODO)</div>} />
+              <Route
+                path="/settings"
+                element={<div>Settings Page (TODO)</div>}
+              />
+              <Route path="/debug" element={<Debug />} />
+              <Route path="/docs/*" element={<Docs />} />
+            </Routes>
+            <VersionInfo />
+          </div>
+        </AudioProvider>
       </AuthProvider>
     </Router>
   )

--- a/frontend/src/pages/Practice.test.tsx
+++ b/frontend/src/pages/Practice.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import Practice from './Practice'
+import { AudioProvider } from '../contexts/AudioContext'
 import { audioManager } from '../utils/audioManager'
 import * as Tone from 'tone'
 
@@ -68,6 +69,7 @@ describe('Practice Page', () => {
     mockAudioManager.initialize.mockResolvedValue()
     mockAudioManager.setInstrument.mockReturnValue()
     mockAudioManager.isInitialized.mockReturnValue(true) // Default to initialized
+    mockAudioManager.getInstrument = jest.fn().mockReturnValue('piano')
 
     // Mock Tone.Master.volume - Create a mock object that simulates Tone.Master
     Object.defineProperty(mockTone, 'Master', {
@@ -82,7 +84,9 @@ describe('Practice Page', () => {
   const renderPractice = () => {
     return render(
       <BrowserRouter>
-        <Practice />
+        <AudioProvider audioManager={mockAudioManager as any}>
+          <Practice />
+        </AudioProvider>
       </BrowserRouter>
     )
   }

--- a/frontend/src/pages/Practice.tsx
+++ b/frontend/src/pages/Practice.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { audioManager } from '../utils/audioManager'
+import { useAudioManager } from '../contexts/AudioContext'
 import {
   moonlightSonata3rdMovement,
   getPlayableNotes,
@@ -17,6 +17,7 @@ import * as Tone from 'tone'
 type PracticeMode = 'practice' | 'sight-read' | 'debug'
 
 const Practice: React.FC = () => {
+  const audioManager = useAudioManager()
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth)
 
   // Control states
@@ -34,7 +35,7 @@ const Practice: React.FC = () => {
   // Set instrument to piano (but don't initialize audio yet)
   useEffect(() => {
     audioManager.setInstrument('piano')
-  }, [])
+  }, [audioManager])
 
   // Handle responsive sizing
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Added AudioProvider context wrapper to App.tsx to fix useAudioManager error
- Updated Practice page to use useAudioManager hook instead of direct import
- Fixed Practice page tests to work with the new AudioProvider requirement

## Problem
The Practice page was throwing an error because the MusicPlayer component uses useAudioManager hook which requires AudioProvider context, but the App.tsx wasn't providing it.

## Solution
1. Import and wrap all routes with AudioProvider in App.tsx
2. Update Practice page to use the useAudioManager hook
3. Update tests to pass mocked audioManager to AudioProvider

## Test plan
- [x] Build succeeds without errors
- [x] Practice page loads without console errors
- [x] Audio functionality works as expected
- [ ] All tests pass after fix

🤖 Generated with [Claude Code](https://claude.ai/code)