### PR TITLE
test: fix Practice test rerender to include AudioProvider

### DIFF
--- a/frontend/src/pages/Practice.test.tsx
+++ b/frontend/src/pages/Practice.test.tsx
@@ -321,7 +321,9 @@ describe('Practice Page', () => {
       // Force re-render to check updated state
       rerender(
         <BrowserRouter>
-          <Practice />
+          <AudioProvider audioManager={mockAudioManager as any}>
+            <Practice />
+          </AudioProvider>
         </BrowserRouter>
       )
 


### PR DESCRIPTION
## Summary
- Fixed the last failing test in Practice.test.tsx after AudioProvider integration
- The window resize test was using rerender without wrapping Practice in AudioProvider

## Problem
After adding AudioProvider to App.tsx, one test was still failing because the rerender function wasn't providing the AudioProvider context.

## Solution
Updated the rerender call in the window resize test to wrap Practice component with AudioProvider.

## Test Results
✅ All 22 test suites now pass (450 tests total)

🤖 Generated with [Claude Code](https://claude.ai/code)