### PR TITLE
fix: resolve ESLint no-extra-semi errors in backend tests

### DIFF
--- a/backend/src/__tests__/unit/index.test.ts
+++ b/backend/src/__tests__/unit/index.test.ts
@@ -74,7 +74,9 @@ describe('Cloudflare Workers Handler', () => {
     }
 
     // Setup default mock implementations
+    // eslint-disable-next-line no-extra-semi
     ;(isOriginAllowed as jest.Mock).mockReturnValue(true)
+    // eslint-disable-next-line no-extra-semi
     ;(getCorsConfig as jest.Mock).mockReturnValue({
       production: {
         domains: ['example.com'],
@@ -128,6 +130,7 @@ describe('Cloudflare Workers Handler', () => {
     })
 
     it('should add CORS headers to allowed origins', async () => {
+      // eslint-disable-next-line no-extra-semi
       ;(isOriginAllowed as jest.Mock).mockReturnValue(true)
 
       const request = new Request('https://api.example.com/health', {
@@ -142,6 +145,7 @@ describe('Cloudflare Workers Handler', () => {
     })
 
     it('should not add origin header for disallowed origins', async () => {
+      // eslint-disable-next-line no-extra-semi
       ;(isOriginAllowed as jest.Mock).mockReturnValue(false)
 
       const request = new Request('https://api.example.com/health', {
@@ -365,6 +369,7 @@ describe('Cloudflare Workers Handler', () => {
     })
 
     it('should create GraphQL context with user when authenticated', async () => {
+      // eslint-disable-next-line no-extra-semi
       ;(verifyJWT as jest.Mock).mockResolvedValue({
         user: { id: 'authenticated-user' },
       })
@@ -401,6 +406,7 @@ describe('Cloudflare Workers Handler', () => {
     })
 
     it('should handle invalid JWT gracefully', async () => {
+      // eslint-disable-next-line no-extra-semi
       ;(verifyJWT as jest.Mock).mockRejectedValue(new Error('Invalid token'))
 
       const request = new Request('https://api.example.com/graphql', {


### PR DESCRIPTION
## Summary
- Fixed ESLint `no-extra-semi` errors in backend test files
- Added `eslint-disable-next-line` comments for necessary semicolons that prevent ASI issues

## Details
The semicolons at the beginning of lines (e.g., `;(isOriginAllowed as jest.Mock)`) are necessary in JavaScript/TypeScript to prevent automatic semicolon insertion (ASI) issues when a line starts with a parenthesis. These were being incorrectly flagged by ESLint's `no-extra-semi` rule.

## Changes
- Added `eslint-disable-next-line no-extra-semi` comments for 5 instances in `backend/src/__tests__/unit/index.test.ts`
- All linter errors are now resolved (0 errors, 0 warnings in backend)

## Test plan
- [x] Linter passes with no errors: `npm run lint`
- [x] All tests pass: `npm test`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)