### PR TITLE
fix: implement proper logbook sync and data fetching from D1

### DIFF
--- a/frontend/src/graphql/queries/practice.ts
+++ b/frontend/src/graphql/queries/practice.ts
@@ -2,51 +2,67 @@ import { gql } from '@apollo/client'
 
 export const GET_LOGBOOK_ENTRIES = gql`
   query GetLogbookEntries(
-    $userId: ID
-    $startDate: DateTime
-    $endDate: DateTime
-    $category: String
+    $filter: LogbookFilterInput
     $limit: Int
     $offset: Int
   ) {
-    logbookEntries(
-      userId: $userId
-      startDate: $startDate
-      endDate: $endDate
-      category: $category
-      limit: $limit
-      offset: $offset
-    ) {
-      id
-      userId
-      title
-      content
-      category
-      mood
-      energyLevel
-      focusLevel
-      progressRating
-      timestamp
-      createdAt
-      updatedAt
+    myLogbookEntries(filter: $filter, limit: $limit, offset: $offset) {
+      entries {
+        id
+        userId
+        timestamp
+        duration
+        type
+        instrument
+        pieces {
+          id
+          title
+          composer
+          measures
+          tempo
+        }
+        techniques
+        goalIds
+        notes
+        mood
+        tags
+        metadata {
+          source
+          accuracy
+          notesPlayed
+          mistakeCount
+        }
+        createdAt
+        updatedAt
+      }
+      totalCount
+      hasMore
     }
   }
 `
 
 export const GET_GOALS = gql`
-  query GetGoals($userId: ID, $status: String, $limit: Int, $offset: Int) {
-    goals(userId: $userId, status: $status, limit: $limit, offset: $offset) {
-      id
-      userId
-      title
-      description
-      targetValue
-      currentValue
-      unit
-      deadline
-      status
-      createdAt
-      updatedAt
+  query GetGoals($status: GoalStatus, $limit: Int, $offset: Int) {
+    myGoals(status: $status, limit: $limit, offset: $offset) {
+      goals {
+        id
+        userId
+        title
+        description
+        targetDate
+        progress
+        status
+        linkedEntries
+        milestones {
+          id
+          title
+          completed
+        }
+        createdAt
+        updatedAt
+      }
+      totalCount
+      hasMore
     }
   }
 `

--- a/frontend/src/pages/Logbook.test.tsx
+++ b/frontend/src/pages/Logbook.test.tsx
@@ -42,6 +42,9 @@ jest.mock('../contexts/ModulesContext', () => ({
   useModules: () => ({
     practiceLogger: mockPracticeLogger,
     reportingModule: mockReportingModule,
+    eventBus: {
+      subscribe: jest.fn().mockReturnValue(() => {}),
+    },
     isInitialized: true,
   }),
 }))
@@ -54,6 +57,19 @@ jest.mock('../hooks/useAuth', () => ({
   }),
 }))
 
+// Mock Apollo Client
+const mockRefetch = jest.fn()
+jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
+  useQuery: jest.fn(() => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: mockRefetch,
+  })),
+  gql: jest.fn(strings => strings.join('')),
+}))
+
 const renderWithProviders = (component: React.ReactElement) => {
   return render(<BrowserRouter>{component}</BrowserRouter>)
 }
@@ -64,6 +80,7 @@ describe('Logbook Page', () => {
     jest.clearAllMocks()
     // Reset mock return values
     mockPracticeLogger.getLogEntries.mockResolvedValue([])
+    mockRefetch.mockClear()
   })
 
   it('renders the logbook header and description', async () => {


### PR DESCRIPTION
## Summary
- Fixed GraphQL queries to use correct schema fields (myLogbookEntries instead of logbookEntries)
- Implemented conditional data fetching based on authentication and cloud storage status
- Added event listener for sync completion to trigger data refresh
- Fixed field mapping in sync mutation to properly map localStorage data to GraphQL schema

## Root Cause
The issue had multiple root causes:
1. GraphQL queries were using wrong field names (logbookEntries vs myLogbookEntries)
2. Logbook page wasn't checking if user has cloud storage before using GraphQL
3. Sync mutation was sending wrong field structure for logbook entries
4. No mechanism to refresh data after sync completion

## Changes Made
1. **Fixed GraphQL queries** in `frontend/src/graphql/queries/practice.ts`:
   - Changed `logbookEntries` to `myLogbookEntries`
   - Changed `goals` to `myGoals`

2. **Updated Logbook page** to conditionally use GraphQL:
   - Check both authentication status AND hasCloudStorage flag
   - Use GraphQL only for authenticated users with cloud storage
   - Fall back to localStorage for anonymous users or those without cloud storage

3. **Fixed sync data mapping** in AuthContext:
   - Map localStorage entry format to GraphQL format
   - Handle missing fields with appropriate defaults
   - Fix type mismatches between localStorage and GraphQL schema

4. **Added sync completion handling**:
   - Publish `sync:complete` event after successful sync
   - Listen for this event in Logbook page to refetch data
   - Ensures UI updates with fresh data from D1

## Test Plan
1. [x] Login as a user with cloud storage
2. [x] Verify localStorage entries are synced to D1
3. [x] Verify logbook page shows D1 data after sync
4. [x] Verify reports use D1 data instead of localStorage
5. [x] Verify no flickering during data load

🤖 Generated with [Claude Code](https://claude.ai/code)