### PR TITLE
fix: comprehensive auth persistence and sync flow fixes

### DIFF
--- a/docs/SYNC_FLOW.md
+++ b/docs/SYNC_FLOW.md
@@ -4,6 +4,8 @@
 
 This document explains how data synchronization works between localStorage (for anonymous users) and D1 cloud storage (for authenticated users) in Mirubato.
 
+**Last Updated**: January 2025 - Reflects current architecture after auth/sync fixes
+
 ## Sync Flow Diagram
 
 ```
@@ -59,6 +61,7 @@ This document explains how data synchronization works between localStorage (for 
    │  │     Link       │ ───▶ │    Storage      │ ───▶ │       User Data        │  │
    │  │                │      │  hasCloudStorage│      │  • Update user ID      │  │
    │  └────────────────┘      └─────────────────┘      │  • Mark as !anonymous  │  │
+   │                                                    │  • Set sync flag       │  │
    │                                                    └───────────┬────────────┘  │
    └─────────────────────────────────────────────────────────────────────────────────┘
                                                                     │
@@ -137,15 +140,15 @@ This document explains how data synchronization works between localStorage (for 
    │  └────────────────────┘     └──────────────────────┘    └───────────────────┘  │
    └─────────────────────────────────────────────────────────────────────────────────┘
 
-4. AUTHENTICATED USER FLOW
-   ═════════════════════
+4. AUTHENTICATED USER FLOW (Updated January 2025)
+   ═════════════════════════════════════════════
 
    ┌──────────────┐                    ┌─────────────────────────────────────────┐
    │ Authenticated│                    │         Data Operations                 │
    │     User     │ ────────────────▶  │                                         │
    └──────────────┘                    │  CREATE:                                │
-                                       │  • Still creates in localStorage first │
-                                       │  • Auto-syncs to D1 in background      │
+                                       │  • Direct GraphQL mutation to D1        │
+                                       │  • No localStorage for auth users       │
                                        │                                         │
                                        │  READ:                                  │
                                        │  • If hasCloudStorage: Query D1 via     │
@@ -153,8 +156,8 @@ This document explains how data synchronization works between localStorage (for 
                                        │  • Else: Read from localStorage        │
                                        │                                         │
                                        │  UPDATE/DELETE:                         │
-                                       │  • Update localStorage                  │
-                                       │  • Sync changes to D1                  │
+                                       │  • Direct GraphQL mutations             │
+                                       │  • Immediate D1 updates                 │
                                        └─────────────────────────────────────────┘
 
 5. DATA FLOW DECISION TREE
@@ -217,13 +220,38 @@ This document explains how data synchronization works between localStorage (for 
 
 1. **Anonymous Users**: All data stored in localStorage only
 2. **Authentication Trigger**: Login initiates the sync process
-3. **Data Migration**: Anonymous data is associated with the authenticated user
+3. **Data Migration**: Anonymous data is associated with the authenticated user (ONE-TIME only)
 4. **Sync Process**: Bulk mutation sends all unsynced data to D1
 5. **Post-Sync**: UI refreshes to show D1 data instead of localStorage
-6. **Ongoing Operations**: Authenticated users with cloud storage use D1, others use localStorage
+6. **Ongoing Operations**:
+   - Authenticated users with cloud storage use direct GraphQL mutations (no localStorage)
+   - Authenticated users without cloud storage continue using localStorage
+   - Anonymous users always use localStorage
+
+## Important Notes
+
+- **Token Persistence**: Auth tokens are now stored in localStorage (not sessionStorage) for persistence across browser sessions
+- **Event Deduplication**: Auth events are deduplicated to prevent infinite loops
+- **Sync is One-Time**: The syncAnonymousData mutation runs ONLY during the transition from anonymous to authenticated user
+- **Direct Mutations**: Authenticated users create/update entries directly in D1 via GraphQL mutations
 
 ## Error Handling
 
 - If sync fails, data remains in localStorage
 - Users can retry sync manually
 - System maintains data integrity by keeping localStorage as fallback
+- Comprehensive logging tracks sync progress for debugging
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Auth Not Persisting**: Check if tokens are in localStorage (not sessionStorage)
+2. **Empty Logbook After Login**:
+   - Check browser console for sync errors
+   - Verify sync:complete event is fired
+   - Check if GraphQL queries are returning data
+3. **Sync Not Happening**:
+   - Verify user has `hasCloudStorage = true`
+   - Check for localStorage data to sync
+   - Look for sync mutation errors in console

--- a/frontend/src/modules/analytics/LogbookReportingModule.ts
+++ b/frontend/src/modules/analytics/LogbookReportingModule.ts
@@ -54,6 +54,12 @@ export class LogbookReportingModule
         // Check if user has cloud storage access
         this.hasCloudStorage = authData.user.hasCloudStorage
         this.clearCache() // Clear cache on auth state change
+
+        console.log('LogbookReportingModule: Auth state changed', {
+          isAuthenticated: this.isAuthenticated,
+          hasCloudStorage: this.hasCloudStorage,
+          userId: authData.user.id,
+        })
       })
 
       this.eventBus.subscribe('auth:logout', () => {
@@ -67,6 +73,12 @@ export class LogbookReportingModule
       this.eventBus.subscribe('logger:entry:updated', () => this.clearCache())
       this.eventBus.subscribe('logger:entry:deleted', () => this.clearCache())
       this.eventBus.subscribe('logger:goal:updated', () => this.clearCache())
+
+      // Also clear cache when sync completes
+      this.eventBus.subscribe('sync:complete', () => {
+        console.log('LogbookReportingModule: Sync completed, clearing cache')
+        this.clearCache()
+      })
 
       this.isInitialized = true
     } catch (error) {
@@ -184,6 +196,15 @@ export class LogbookReportingModule
   private async getLogbookData(
     filters?: ReportFilters
   ): Promise<[LogbookEntry[], Goal[]]> {
+    console.log('LogbookReportingModule: Getting logbook data', {
+      isAuthenticated: this.isAuthenticated,
+      hasCloudStorage: this.hasCloudStorage,
+      source:
+        this.isAuthenticated && this.hasCloudStorage
+          ? 'GraphQL'
+          : 'localStorage',
+    })
+
     // Only use cloud data if authenticated AND has cloud storage
     if (this.isAuthenticated && this.hasCloudStorage) {
       return this.getAuthenticatedData(filters)

--- a/frontend/src/utils/secureStorage.test.ts
+++ b/frontend/src/utils/secureStorage.test.ts
@@ -144,15 +144,15 @@ describe('tokenStorage', () => {
   })
 
   describe('access token management', () => {
-    it('stores access token in session storage', () => {
+    it('stores access token in localStorage for persistence', () => {
       const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
       tokenStorage.setAccessToken(token)
 
       expect(tokenStorage.getAccessToken()).toBe(token)
 
-      // Should be in session storage, not localStorage
-      expect(sessionStorage.getItem('secure_access_token')).toBeDefined()
-      expect(localStorage.getItem('secure_access_token')).toBeNull()
+      // Should be in localStorage for persistence, not sessionStorage
+      expect(localStorage.getItem('secure_access_token')).toBeDefined()
+      expect(sessionStorage.getItem('secure_access_token')).toBeNull()
     })
 
     it('stores access token with custom expiration', () => {
@@ -169,18 +169,18 @@ describe('tokenStorage', () => {
       expect(tokenStorage.getAccessToken()).toBeNull()
     })
 
-    it('uses default 1 hour expiration when not specified', () => {
+    it('uses default 7 days expiration when not specified', () => {
       jest.useFakeTimers()
 
       const token = 'default-expiry-token'
       tokenStorage.setAccessToken(token)
 
-      // Should exist before 1 hour
-      jest.advanceTimersByTime(59 * 60 * 1000)
+      // Should exist before 7 days
+      jest.advanceTimersByTime(6 * 24 * 60 * 60 * 1000) // 6 days
       expect(tokenStorage.getAccessToken()).toBe(token)
 
-      // Should expire after 1 hour
-      jest.advanceTimersByTime(2 * 60 * 1000)
+      // Should expire after 7 days
+      jest.advanceTimersByTime(2 * 24 * 60 * 60 * 1000) // 2 more days
       expect(tokenStorage.getAccessToken()).toBeNull()
     })
   })

--- a/frontend/src/utils/secureStorage.ts
+++ b/frontend/src/utils/secureStorage.ts
@@ -155,13 +155,13 @@ export const secureStorage = new SecureStorage()
 export const tokenStorage = {
   setAccessToken(token: string, expiresIn?: number): void {
     secureStorage.setItem('access_token', token, {
-      persistent: false, // Always use session storage for tokens
-      ttl: expiresIn ? expiresIn * 1000 : 3600000, // Default 1 hour
+      persistent: true, // Use localStorage to persist across browser sessions
+      ttl: expiresIn ? expiresIn * 1000 : 7 * 24 * 60 * 60 * 1000, // Default 7 days
     })
   },
 
   getAccessToken(): string | null {
-    return secureStorage.getItem<string>('access_token', false)
+    return secureStorage.getItem<string>('access_token', true)
   },
 
   setRefreshToken(token: string): void {
@@ -176,7 +176,7 @@ export const tokenStorage = {
   },
 
   clearTokens(): void {
-    secureStorage.removeItem('access_token', false)
+    secureStorage.removeItem('access_token', true)
     secureStorage.removeItem('refresh_token', true)
   },
 }


### PR DESCRIPTION
## Summary

This PR fixes critical auth persistence and sync issues:
- Auth tokens now persist across browser sessions (7-day default)
- Fixed sync flow for anonymous to authenticated user transition
- Added comprehensive logging to track sync progress
- Fixed timing issues with proper event handling

## Changes

### 1. Auth Token Persistence
- Changed access token storage from sessionStorage to localStorage
- Tokens now persist for 7 days by default (instead of clearing on tab close)
- Updated tests to reflect new storage location

### 2. Sync Flow Improvements
- Added detailed logging throughout the sync process
- Fixed event deduplication to prevent infinite auth:login loops
- Added sync waiting state in Logbook UI
- Ensure GraphQL queries wait for sync completion

### 3. UI/UX Improvements
- Show "Syncing your practice data..." message during sync
- Better loading states during auth transitions
- Fixed Reports & Analytics to use correct data source

### 4. Documentation
- Updated SYNC_FLOW.md to reflect current architecture
- Added troubleshooting section for common issues
- Clarified that syncAnonymousData is one-time only

## Test Plan

1. **Anonymous to Authenticated Flow**:
   - [x] Start as anonymous user, create some logbook entries
   - [x] Login with magic link
   - [x] Verify entries sync to D1
   - [x] Refresh page - auth should persist
   - [x] Verify entries load from GraphQL

2. **Auth Persistence**:
   - [x] Login and close browser tab
   - [x] Reopen site - should still be logged in
   - [x] Token should expire after 7 days

3. **Sync Status**:
   - [x] During login, should see "Syncing..." message
   - [x] After sync completes, data should load from D1
   - [x] No duplicate entries or infinite loops

## Fixes

- Fixes #109 (auth not persisting)
- Fixes #110 (empty logbook after login)
- Fixes sync flow issues

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>