### PR TITLE
fix: resolve auth redirect race condition and sync failures

### DIFF
--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -874,6 +874,17 @@ describe('AuthContext', () => {
       mockLocalStorage.getUserData.mockReturnValue(mockUser)
       mockLocalStorage.getPendingSyncData.mockReturnValue(mockPendingData)
 
+      // Mock localStorage.getItem for access-token
+      const mockGetItem = jest.fn()
+      mockGetItem.mockReturnValue('mock-access-token')
+      Object.defineProperty(window, 'localStorage', {
+        value: {
+          ...window.localStorage,
+          getItem: mockGetItem,
+        },
+        writable: true,
+      })
+
       const mocks = [
         {
           request: {
@@ -996,6 +1007,17 @@ describe('AuthContext', () => {
         throw new Error('Sync data error')
       })
 
+      // Mock localStorage.getItem to return null for access-token
+      const mockGetItem = jest.fn()
+      mockGetItem.mockReturnValue(null)
+      Object.defineProperty(window, 'localStorage', {
+        value: {
+          ...window.localStorage,
+          getItem: mockGetItem,
+        },
+        writable: true,
+      })
+
       const mocks = [
         {
           request: {
@@ -1021,7 +1043,9 @@ describe('AuthContext', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByTestId('error')).toHaveTextContent('Sync data error')
+        expect(screen.getByTestId('error')).toHaveTextContent(
+          'Authentication required for sync'
+        )
       })
     })
   })


### PR DESCRIPTION
## Summary

This PR fixes three critical authentication and sync issues reported in TYPE_ALIGNMENT_AUDIT.md:

1. **Auth redirect race condition** - 'Failed to login' briefly appears before successful auth
2. **Apollo 'Not authenticated' errors** - Multiple sync failures after login
3. **Local entries not displayed** - Logbook shows empty despite having data

## Changes

### 1. Fixed Auth Redirect Race Condition
- Added separate syncError state in AuthContext to distinguish login errors from sync errors
- Sync errors now display as informational messages rather than login failures
- Auto-clear sync errors after 5 seconds with user-friendly messaging

### 2. Fixed Apollo Authentication Errors
- Increased delay before sync from 500ms to 1000ms to ensure Apollo client is fully updated
- Added validation to check for access token before attempting sync
- Better error handling for sync failures that doesn't interfere with login success

### 3. Fixed Local Entries Display
- Added errorPolicy: 'all' to GraphQL queries to continue even with errors
- Implemented fallback to local data when GraphQL fails
- Shows informative message: 'Using local data. Your entries will sync when connection is restored.'
- Ensures entries are always visible, whether from cloud or local storage

## Testing

- [x] Guest user can create practice sessions
- [x] Login via magic link works without 'failed' message
- [x] Data syncs after authentication (or shows graceful error)
- [x] Logbook displays entries even when sync fails
- [x] All unit tests passing

## Screenshots

The console still shows some non-critical errors related to module initialization timing, but the user experience is now smooth:
- Login succeeds immediately
- Sync happens in background
- Data is always visible (local or cloud)

## Related

- Fixes issues documented in docs/TYPE_ALIGNMENT_AUDIT.md
- Addresses GitHub issues related to auth flow

🤖 Generated with Claude Code (https://claude.ai/code)