### PR TITLE
fix: correct table name from practice_goals to goals in sync resolver

### DIFF
--- a/backend/src/resolvers/sync.ts
+++ b/backend/src/resolvers/sync.ts
@@ -92,7 +92,7 @@ export const syncResolvers = {
           .bind(userId, since)
           .all(),
         ctx.env.DB.prepare(
-          'SELECT * FROM practice_goals WHERE user_id = ? AND updated_at > ? AND deleted_at IS NULL'
+          'SELECT * FROM goals WHERE user_id = ? AND updated_at > ? AND deleted_at IS NULL'
         )
           .bind(userId, since)
           .all(),
@@ -215,7 +215,7 @@ export const syncResolvers = {
           .bind(userId)
           .all(),
         ctx.env.DB.prepare(
-          'SELECT * FROM practice_goals WHERE user_id = ? AND deleted_at IS NULL'
+          'SELECT * FROM goals WHERE user_id = ? AND deleted_at IS NULL'
         )
           .bind(userId)
           .all(),
@@ -464,7 +464,7 @@ async function syncGoal(entity: SyncEntityInput, ctx: Context) {
   const id = entity.remoteId || nanoid()
 
   const existing = await ctx.env.DB.prepare(
-    'SELECT id, sync_version, checksum FROM practice_goals WHERE id = ?'
+    'SELECT id, sync_version, checksum FROM goals WHERE id = ?'
   )
     .bind(id)
     .first()
@@ -488,7 +488,7 @@ async function syncGoal(entity: SyncEntityInput, ctx: Context) {
     }
 
     await ctx.env.DB.prepare(
-      `UPDATE practice_goals 
+      `UPDATE goals 
        SET title = ?, description = ?, target_date = ?, 
            progress = ?, status = ?, milestones = ?,
            completed_at = ?, sync_version = ?, checksum = ?, 
@@ -510,7 +510,7 @@ async function syncGoal(entity: SyncEntityInput, ctx: Context) {
       .run()
   } else {
     await ctx.env.DB.prepare(
-      `INSERT INTO practice_goals 
+      `INSERT INTO goals 
        (id, user_id, title, description, target_date, progress,
         status, milestones, linked_entries, created_at, updated_at,
         completed_at, sync_version, checksum)


### PR DESCRIPTION
The sync resolver was looking for 'practice_goals' table but the actual table is named 'goals' according to the migration file 0007_create_goals.sql. This was causing sync failures with "no such table: practice_goals" error.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
Brief description of changes and motivation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Musical Content Review
- [ ] Musical theory accuracy verified
- [ ] Pedagogical approach validated
- [ ] Instrument-specific considerations addressed

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing done

## Accessibility
- [ ] Keyboard navigation tested
- [ ] Screen reader compatibility verified
- [ ] Color contrast requirements met
- [ ] Mobile accessibility validated

## Performance
- [ ] No performance regressions introduced
- [ ] Bundle size impact assessed
- [ ] Audio latency tested
- [ ] Memory usage profiled