### PR TITLE
fix: correct scores service wrangler.toml for production deployment

### DIFF
--- a/scores/package.json
+++ b/scores/package.json
@@ -12,7 +12,7 @@
     "db:migrate": "wrangler d1 migrations apply DB --local",
     "db:migrate:dev": "wrangler d1 migrations apply DB --env dev",
     "db:migrate:staging": "wrangler d1 migrations apply DB --env staging",
-    "db:migrate:production": "wrangler d1 migrations apply DB --env production",
+    "db:migrate:production": "wrangler d1 migrations apply DB",
     "test": "vitest",
     "test:coverage": "vitest --coverage"
   },

--- a/scores/wrangler.toml
+++ b/scores/wrangler.toml
@@ -3,37 +3,22 @@ main = "src/index.ts"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Local development databases
-[[d1_databases]]
-binding = "DB"
-database_name = "mirubato-scores-local"
-database_id = "local"
-
-[[r2_buckets]]
-binding = "SCORES_BUCKET"
-bucket_name = "mirubato-scores-local"
-
-[[kv_namespaces]]
-binding = "CACHE"
-id = "local"
-
-# Production configuration (default)
-[env.production]
+# Production configuration (default - no env flag needed)
 vars = { ENVIRONMENT = "production" }
 routes = [
   { pattern = "scores.mirubato.com", custom_domain = true }
 ]
 
-[[env.production.d1_databases]]
+[[d1_databases]]
 binding = "DB"
 database_name = "mirubato-scores-production"
 database_id = "aac4662e-d14a-4397-971c-c544d8c79104"
 
-[[env.production.r2_buckets]]
+[[r2_buckets]]
 binding = "SCORES_BUCKET"
 bucket_name = "mirubato-scores-production"
 
-[[env.production.kv_namespaces]]
+[[kv_namespaces]]
 binding = "CACHE"
 id = "1f30ff61b4a04dc4a9a269ad6f828fe4"
 


### PR DESCRIPTION
## Summary

This PR fixes the scores service deployment error that occurred after merging the API service migration.

## Problem

The scores service was failing to deploy with the error:
```
KV namespace 'local' is not valid.  [code: 10042]
```

This happened because the `wrangler.toml` had local development bindings at the top level, which were being used during production deployment.

## Solution

- Moved production configuration to top-level (default configuration)
- Local development configuration remains under `[env.local]` section
- Updated `db:migrate:production` script to not use `--env` flag since production is now the default

## Changes

1. **scores/wrangler.toml**: Restructured to make production the default configuration
2. **scores/package.json**: Updated production migration script

## Testing

- Built the scores service locally: ✅
- Verified configuration structure: ✅

## Deployment

After merging this PR, the scores service should deploy correctly to production without the KV namespace error.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>