### PR TITLE
fix: configure API service with correct D1 database IDs

### DIFF
--- a/api/DATABASE_SETUP.md
+++ b/api/DATABASE_SETUP.md
@@ -1,0 +1,51 @@
+# API Service Database Setup
+
+## Overview
+
+The API service uses Cloudflare D1 databases that are shared with the existing backend service. This ensures data consistency during the migration period.
+
+## Database Configuration
+
+### Production Database
+
+- **Name**: mirubato-prod
+- **ID**: 31ecc854-aecf-4994-8bda-7a9cd3055122
+- **Binding**: DB
+
+### Development/Staging Database
+
+- **Name**: mirubato-dev
+- **ID**: 4510137a-7fdf-4fcd-83c9-a1b0adb7fe3e
+- **Binding**: DB
+
+## Important Notes
+
+1. **Shared Databases**: The API service uses the same D1 databases as the backend service. This is intentional to ensure both services can operate on the same data during the transition period.
+
+2. **No KV Storage Needed**: Unlike the backend service, the API service uses stateless JWT tokens for magic links, so it doesn't require KV storage.
+
+3. **Database Migrations**: Since we're using existing databases, no new migrations are needed. The API service is designed to work with the existing schema.
+
+## Deployment
+
+The databases are already created and configured in Cloudflare. When deploying the API service:
+
+1. The production deployment will automatically use the production database
+2. The staging deployment will use the development database
+3. Local development will also use the development database
+
+## Troubleshooting
+
+If you encounter database binding errors during deployment:
+
+1. Verify the database IDs match those in your Cloudflare account
+2. Ensure your account has access to these databases
+3. Check that the database names haven't been changed in Cloudflare
+
+## Future Considerations
+
+When the API service fully replaces the backend service:
+
+1. The backend service can be decommissioned
+2. The databases will remain unchanged
+3. Consider renaming databases for clarity (e.g., mirubato-api-prod instead of mirubato-prod)

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -1,7 +1,7 @@
 name = "mirubato-api"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-node_compat = true
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "npm run build"
@@ -12,8 +12,8 @@ vars = { ENVIRONMENT = "local", JWT_SECRET = "local-jwt-secret-for-development-o
 
 [[env.local.d1_databases]]
 binding = "DB"
-database_name = "mirubato-local"
-database_id = "00000000-0000-0000-0000-000000000000"
+database_name = "mirubato-dev"
+database_id = "4510137a-7fdf-4fcd-83c9-a1b0adb7fe3e"
 
 # Staging environment
 [env.staging]
@@ -24,8 +24,8 @@ routes = [
 
 [[env.staging.d1_databases]]
 binding = "DB"
-database_name = "mirubato-api-staging"
-database_id = "00000000-0000-0000-0000-000000000001"
+database_name = "mirubato-dev"
+database_id = "4510137a-7fdf-4fcd-83c9-a1b0adb7fe3e"
 
 # Rate limiting for staging
 [[env.staging.unsafe.bindings]]
@@ -45,8 +45,8 @@ custom_domain = true
 
 [[d1_databases]]
 binding = "DB"
-database_name = "mirubato-api-production"
-database_id = "00000000-0000-0000-0000-000000000002"
+database_name = "mirubato-prod"
+database_id = "31ecc854-aecf-4994-8bda-7a9cd3055122"
 
 # Rate limiting configuration
 [[unsafe.bindings]]


### PR DESCRIPTION
## Summary
- Fixed Cloudflare deployment error by configuring correct D1 database IDs
- API service now uses the same databases as the backend service
- Added documentation for database setup

## Problem
The deployment was failing with:
```
binding DB of type d1 must have a database that already exists
```

The API service was trying to bind to placeholder database IDs that don't exist.

## Solution
Updated the API service to use the same D1 databases as the backend service:
- **Production**: mirubato-prod (31ecc854-aecf-4994-8bda-7a9cd3055122)
- **Development/Staging**: mirubato-dev (4510137a-7fdf-4fcd-83c9-a1b0adb7fe3e)

This approach ensures both services can operate on the same data during the migration period.

## Changes
- `api/wrangler.toml`: 
  - Updated D1 database IDs to match backend service
  - Changed `node_compat` to `nodejs_compat` as recommended
  - Removed unnecessary KV namespace configurations (API uses stateless JWT)
- `api/DATABASE_SETUP.md`: Added documentation explaining the database configuration

## Test plan
- [x] Build passes locally
- [x] All tests pass
- [ ] Deploy to Cloudflare succeeds
- [ ] API service can connect to databases

## Notes
- The API service intentionally shares databases with the backend service
- No new database migrations are needed
- KV namespaces are not required (API uses stateless JWT tokens for magic links)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>