### PR TITLE
docs: update ROADMAP and DESIGN to reflect completed REST API migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Open-source practice journal for musicians - track sessions, log progress, and a
 ## Quick Start
 
 ```bash
-git clone https://github.com/pezware/mirubato.git && cd mirubato
+git clone https://github.com/pezware/mirubato.git && cd frontendv2
 npm install && npm run dev     # Frontend: localhost:3000
-npm run dev:backend           # API: localhost:8787
+npm run dev:api                # API: localhost:8787
 ```
 
 ## Documentation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,13 +1,15 @@
 # Mirubato Development Roadmap
 
-## Current Status (December 2024)
+## Current Status (January 2025)
 
-✅ **Migration Complete**: Successfully transitioned from GraphQL to REST API architecture
+✅ **REST API Migration Complete**: Full transition from GraphQL to REST API architecture completed
 
-- Legacy frontend/backend removed
-- All data migrated (80 logbook entries, 3 users)
+- GraphQL backend service completely removed
+- Frontend fully migrated to REST API endpoints
+- All data successfully migrated (80 logbook entries, 3 users)
 - Production deployment active at mirubato.com
 - 135 tests passing across all services (API: 32, Scores: 3, Frontend: 100)
+- No GraphQL dependencies remain in the codebase
 
 ## Priority 1: Frontend Polish & UX (2-3 weeks)
 
@@ -147,23 +149,12 @@
 
 ## Long-term Vision (6+ months)
 
-### MusicXML Integration with Scores Service
+### Basic Features
 
-**Goal**: Move MusicXML converter functionality to scores service
-
-**Current State**: MusicXML converter exists in legacy codebase
-
-- ✅ Converts MXL files to TypeScript Score format
-- ✅ Supports multi-voice notation and complex musical notation
-- ✅ Successfully converted Bach, Mozart, and Chopin pieces
-
-**Migration Plan**:
-
-- [ ] Extract converter logic to scores service
-- [ ] Add MusicXML processing endpoints
-- [ ] Integrate with scorebook for automatic score generation
-- [ ] Add real-time notation rendering
-- [ ] Support collaborative music editing
+- [ ] Logbook - comprehensive logbook to track everyday practices
+- [ ] Scorebook - curated score for each grade and level
+- [ ] Gradebook - for teachers to grade the practices, or self evaluation
+- [ ] Goalbook - specified goal with comprehensive steps of practices.
 
 ### Advanced Features
 
@@ -223,5 +214,5 @@
 
 ---
 
-**Next Review**: End of January 2025
-**Last Updated**: December 2024
+**Next Review**: End of June 2025
+**Last Updated**: June 2025


### PR DESCRIPTION
## Summary
- Updated documentation to reflect that the GraphQL to REST API migration is complete
- Removed all references to the deprecated GraphQL backend service
- Updated architecture diagrams and development instructions

## Changes Made

### ROADMAP.md
- Updated status from December 2024 to January 2025
- Added explicit confirmation that REST API migration is complete
- Noted that GraphQL backend service is completely removed
- Updated review dates

### DESIGN.md
- Removed all references to GraphQL backend service
- Removed mentions of "API v2" (now just "API")
- Updated architecture diagram to show REST-only setup
- Removed migration strategy section (migration complete)
- Updated technology stack (removed Apollo, added Axios)
- Updated development commands (`backend` → `api`)
- Cleaned up database schema references

## Test Results
✅ All pre-commit checks passed:
- 135 tests passing (API: 32, Scores: 3, Frontend: 100)
- TypeScript type checking successful
- Prettier formatting applied

🤖 Generated with [Claude Code](https://claude.ai/code)