### PR TITLE
fix: correct logbook entry sorting and timeline navigation

### DIFF
--- a/frontendv2/.gitignore
+++ b/frontendv2/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+ctrf/*

--- a/frontendv2/src/components/LogbookEntryList.tsx
+++ b/frontendv2/src/components/LogbookEntryList.tsx
@@ -95,12 +95,43 @@ export default function LogbookEntryList({
     }
   }, [entries])
 
-  // Timeline levels
-  const timelineLevels: TimelineLevel[] = [
-    { label: '2025', value: 'year', level: 'year' },
-    { label: 'June', value: 'month', level: 'month' },
-    { label: 'Week 4', value: 'week', level: 'week' },
-  ]
+  // Get current date for timeline navigation
+  const currentDate = new Date()
+
+  // Calculate the current week number of the month
+  const getWeekOfMonth = (date: Date) => {
+    const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 1)
+    const dayOfMonth = date.getDate()
+    const dayOfWeek = firstDayOfMonth.getDay()
+    return Math.ceil((dayOfMonth + dayOfWeek) / 7)
+  }
+
+  // Generate timeline levels based on entries
+  const timelineLevels: TimelineLevel[] = useMemo(() => {
+    if (entries.length === 0) {
+      const year = currentDate.getFullYear()
+      const month = currentDate.toLocaleDateString('en-US', { month: 'long' })
+      const week = getWeekOfMonth(currentDate)
+      return [
+        { label: year.toString(), value: 'year', level: 'year' },
+        { label: month, value: 'month', level: 'month' },
+        { label: `Week ${week}`, value: 'week', level: 'week' },
+      ]
+    }
+
+    // Get the most recent entry date
+    const mostRecentEntry = entries[0] // Already sorted by timestamp
+    const entryDate = new Date(mostRecentEntry.timestamp)
+    const year = entryDate.getFullYear()
+    const month = entryDate.toLocaleDateString('en-US', { month: 'long' })
+    const week = getWeekOfMonth(entryDate)
+
+    return [
+      { label: year.toString(), value: 'year', level: 'year' },
+      { label: month, value: 'month', level: 'month' },
+      { label: `Week ${week}`, value: 'week', level: 'week' },
+    ]
+  }, [entries, currentDate])
 
   if (editingEntry) {
     return (

--- a/frontendv2/src/stores/logbookStore.ts
+++ b/frontendv2/src/stores/logbookStore.ts
@@ -83,6 +83,13 @@ const mapToSortedArray = <T extends { createdAt: string }>(
   )
 }
 
+// Helper specifically for sorting logbook entries by practice time
+const sortEntriesByTimestamp = (entries: LogbookEntry[]): LogbookEntry[] => {
+  return entries.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  )
+}
+
 export const useLogbookStore = create<LogbookState>((set, get) => ({
   entriesMap: new Map(),
   goalsMap: new Map(),
@@ -107,7 +114,7 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
       const entriesMap = new Map(entries.map(entry => [entry.id, entry]))
       set({
         entriesMap,
-        entries: mapToSortedArray(entriesMap),
+        entries: sortEntriesByTimestamp(Array.from(entriesMap.values())),
         isLoading: false,
       })
 
@@ -123,7 +130,9 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
             )
             set({
               entriesMap: newEntriesMap,
-              entries: mapToSortedArray(newEntriesMap),
+              entries: sortEntriesByTimestamp(
+                Array.from(newEntriesMap.values())
+              ),
             })
 
             // Debounced write to localStorage
@@ -164,7 +173,7 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
       newEntriesMap.set(entry.id, entry)
       set({
         entriesMap: newEntriesMap,
-        entries: mapToSortedArray(newEntriesMap),
+        entries: sortEntriesByTimestamp(Array.from(newEntriesMap.values())),
       })
 
       // Immediate write to localStorage for new entries
@@ -186,7 +195,9 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
               updatedEntriesMap.set(serverEntry.id, serverEntry)
               set({
                 entriesMap: updatedEntriesMap,
-                entries: mapToSortedArray(updatedEntriesMap),
+                entries: sortEntriesByTimestamp(
+                  Array.from(updatedEntriesMap.values())
+                ),
               })
 
               debouncedLocalStorageWrite(
@@ -227,7 +238,7 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
         newEntriesMap.set(id, updatedEntry)
         set({
           entriesMap: newEntriesMap,
-          entries: mapToSortedArray(newEntriesMap),
+          entries: sortEntriesByTimestamp(Array.from(newEntriesMap.values())),
         })
 
         debouncedLocalStorageWrite(
@@ -242,7 +253,7 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
         newEntriesMap.set(id, updated)
         set({
           entriesMap: newEntriesMap,
-          entries: mapToSortedArray(newEntriesMap),
+          entries: sortEntriesByTimestamp(Array.from(newEntriesMap.values())),
         })
 
         debouncedLocalStorageWrite(
@@ -267,7 +278,7 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
         newEntriesMap.delete(id)
         set({
           entriesMap: newEntriesMap,
-          entries: mapToSortedArray(newEntriesMap),
+          entries: sortEntriesByTimestamp(Array.from(newEntriesMap.values())),
         })
 
         immediateLocalStorageWrite(
@@ -282,7 +293,7 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
         newEntriesMap.delete(id)
         set({
           entriesMap: newEntriesMap,
-          entries: mapToSortedArray(newEntriesMap),
+          entries: sortEntriesByTimestamp(Array.from(newEntriesMap.values())),
         })
 
         immediateLocalStorageWrite(
@@ -574,7 +585,7 @@ export const useLogbookStore = create<LogbookState>((set, get) => ({
       // Update state with merged entries
       set({
         entriesMap: mergedEntriesMap,
-        entries: mapToSortedArray(mergedEntriesMap),
+        entries: sortEntriesByTimestamp(Array.from(mergedEntriesMap.values())),
         isLoading: false,
         isLocalMode: false,
       })

--- a/frontendv2/src/tests/unit/stores/logbookStore.sorting.test.ts
+++ b/frontendv2/src/tests/unit/stores/logbookStore.sorting.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react'
+import { useLogbookStore } from '../../../stores/logbookStore'
+import type { LogbookEntry } from '../../../api/logbook'
+
+// Mock localStorage
+const localStorageData: Record<string, string> = {}
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageData[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageData[key] = value
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete localStorageData[key]
+  }),
+  clear: vi.fn(() => {
+    Object.keys(localStorageData).forEach(key => delete localStorageData[key])
+  }),
+}
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+describe('logbookStore sorting', () => {
+  beforeEach(() => {
+    // Reset the store
+    useLogbookStore.setState({
+      entriesMap: new Map(),
+      entries: [],
+      isLoading: false,
+      error: null,
+    })
+    // Clear localStorage data
+    Object.keys(localStorageData).forEach(key => delete localStorageData[key])
+    vi.clearAllMocks()
+  })
+
+  it('should sort entries by timestamp in descending order', async () => {
+    // Create entries with different timestamps
+    const entries: LogbookEntry[] = [
+      {
+        id: 'entry-1',
+        timestamp: '2025-06-25T14:34:00Z', // 2:34 PM
+        duration: 30,
+        type: 'PRACTICE',
+        instrument: 'PIANO',
+        pieces: [],
+        techniques: [],
+        goalIds: [],
+        tags: [],
+        createdAt: '2025-06-25T14:35:00Z', // Created later
+        updatedAt: '2025-06-25T14:35:00Z',
+      },
+      {
+        id: 'entry-2',
+        timestamp: '2025-06-25T10:42:00Z', // 10:42 AM (earlier)
+        duration: 30,
+        type: 'PRACTICE',
+        instrument: 'PIANO',
+        pieces: [],
+        techniques: [],
+        goalIds: [],
+        tags: [],
+        createdAt: '2025-06-25T14:00:00Z', // Created earlier
+        updatedAt: '2025-06-25T14:00:00Z',
+      },
+      {
+        id: 'entry-3',
+        timestamp: '2025-06-24T22:48:00Z', // Previous day
+        duration: 30,
+        type: 'LESSON',
+        instrument: 'GUITAR',
+        pieces: [],
+        techniques: [],
+        goalIds: [],
+        tags: [],
+        createdAt: '2025-06-25T14:30:00Z', // Created recently
+        updatedAt: '2025-06-25T14:30:00Z',
+      },
+    ]
+
+    // Store entries in localStorage
+    localStorageData['mirubato:logbook:entries'] = JSON.stringify(entries)
+
+    // Load entries
+    await act(async () => {
+      await useLogbookStore.getState().loadEntries()
+    })
+
+    const state = useLogbookStore.getState()
+
+    // Verify entries are sorted by timestamp (most recent first)
+    expect(state.entries).toHaveLength(3)
+    expect(state.entries[0].id).toBe('entry-1') // 2:34 PM today
+    expect(state.entries[1].id).toBe('entry-2') // 10:42 AM today
+    expect(state.entries[2].id).toBe('entry-3') // Previous day
+
+    // Verify the timestamps are in descending order
+    const timestamps = state.entries.map(e => new Date(e.timestamp).getTime())
+    expect(timestamps[0]).toBeGreaterThan(timestamps[1])
+    expect(timestamps[1]).toBeGreaterThan(timestamps[2])
+  })
+})


### PR DESCRIPTION
- Fix entries to sort by practice timestamp instead of creation time
- Add sortEntriesByTimestamp helper to properly order by when practice occurred
- Update timeline navigation to show dynamic dates based on actual entries
- Add proper week calculation for timeline display
- Add unit test to verify sorting behavior

This ensures entries appear in correct chronological order (most recent first) based on when the practice/lesson actually happened, not when it was logged.

🤖 Generated with [Claude Code](https://claude.ai/code)