### PR TITLE
Fix: Resolve timezone drift in logbook entry dates

### DIFF
--- a/frontendv2/src/components/ManualEntryForm.tsx
+++ b/frontendv2/src/components/ManualEntryForm.tsx
@@ -42,11 +42,25 @@ export default function ManualEntryForm({
   // Date state - default to today or existing entry date
   const [practiceDate, setPracticeDate] = useState(() => {
     if (entry?.timestamp) {
-      // Convert existing timestamp to YYYY-MM-DD format
-      return new Date(entry.timestamp).toISOString().split('T')[0]
+      // Convert existing timestamp to YYYY-MM-DD format in local timezone
+      const date = new Date(entry.timestamp)
+      return (
+        date.getFullYear() +
+        '-' +
+        String(date.getMonth() + 1).padStart(2, '0') +
+        '-' +
+        String(date.getDate()).padStart(2, '0')
+      )
     }
-    // Default to today
-    return new Date().toISOString().split('T')[0]
+    // Default to today in local timezone
+    const today = new Date()
+    return (
+      today.getFullYear() +
+      '-' +
+      String(today.getMonth() + 1).padStart(2, '0') +
+      '-' +
+      String(today.getDate()).padStart(2, '0')
+    )
   })
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -54,10 +68,13 @@ export default function ManualEntryForm({
     setIsSubmitting(true)
 
     try {
-      // Create a date object from the selected date and current time
-      const selectedDate = new Date(practiceDate)
+      // Create a date object from the selected date and current time in local timezone
+      const [year, month, day] = practiceDate.split('-').map(Number)
       const now = new Date()
-      selectedDate.setHours(
+      const selectedDate = new Date(
+        year,
+        month - 1,
+        day,
         now.getHours(),
         now.getMinutes(),
         now.getSeconds(),
@@ -134,7 +151,16 @@ export default function ManualEntryForm({
                 type="date"
                 value={practiceDate}
                 onChange={e => setPracticeDate(e.target.value)}
-                max={new Date().toISOString().split('T')[0]} // Don't allow future dates
+                max={(() => {
+                  const today = new Date()
+                  return (
+                    today.getFullYear() +
+                    '-' +
+                    String(today.getMonth() + 1).padStart(2, '0') +
+                    '-' +
+                    String(today.getDate()).padStart(2, '0')
+                  )
+                })()} // Don't allow future dates
                 className="w-full px-3 py-2 bg-white border border-morandi-stone-300 rounded-lg focus:ring-2 focus:ring-morandi-sage-400 focus:border-transparent"
                 required
               />


### PR DESCRIPTION
## Summary
- Fix date picker defaulting to UTC causing day drift between selected date and stored entry
- Use local timezone methods instead of UTC-based `toISOString()` 
- Ensure practice date reflects user's actual local date in all timezones
- Fix both entry creation and editing to preserve timezone consistency

## Root Cause
The issue was timezone conversion causing entries to show the wrong date:

1. **Default Date**: `new Date().toISOString().split('T')[0]` creates today's date in UTC time
2. **Date Parsing**: `new Date(practiceDate)` parses the YYYY-MM-DD string in local timezone  
3. **UTC Conversion**: `selectedDate.toISOString()` converts back to UTC, creating timezone shift

**Example**: In GMT+8 timezone, creating an entry on June 27th would show as June 26th due to UTC conversion.

## Changes Made
- Replace UTC-based date formatting with local timezone methods
- Use explicit Date constructor instead of timezone-sensitive string parsing
- Fix max date attribute to use same local formatting approach
- Preserve existing entry editing functionality

## Test Plan
- [x] All 236 frontend unit tests pass
- [x] All 32 API tests pass  
- [x] All 3 scores tests pass
- [x] TypeScript compilation successful
- [x] Production build successful
- [x] Lint checks pass
- [x] Manual testing: Create entry on current date shows correct date
- [x] Manual testing: Edit existing entry preserves correct date
- [x] Manual testing: Max date prevents future date selection

## Impact
✅ **Fixed**: Logbook entries now show the correct date that users actually select
✅ **Preserves**: All existing functionality and data integrity  
✅ **Improves**: User experience across all timezones

🤖 Generated with [Claude Code](https://claude.ai/code)