### PR TITLE
fix: remove permalink from docs.html to fix 404

### DIFF
--- a/dashboard/docs.html
+++ b/dashboard/docs.html
@@ -1,7 +1,6 @@
 ---
 layout: doc
 title: Documentation Index
-permalink: /docs/
 ---
 
 <h1>Mirubato Documentation</h1>


### PR DESCRIPTION
## Summary
Remove the `permalink: /docs/` from docs.html that was causing Jekyll to serve the page at `/docs/` instead of `/docs.html`.

## Problem
The docs.html page was returning a 404 error when accessed at https://docs.mirubato.com/docs.html

## Solution
Removed the permalink front matter so Jekyll serves the file at its natural location (docs.html).

## Test plan
- [ ] Deploy and verify https://docs.mirubato.com/docs.html loads correctly
- [ ] Click "Browse Docs" button on dashboard and verify it navigates to the documentation index

🤖 Generated with [Claude Code](https://claude.ai/code)