### PR TITLE
fix: GitHub Actions backup workflow - remove incorrect --env flag

### DIFF
--- a/.github/workflows/scheduled-backup.yml
+++ b/.github/workflows/scheduled-backup.yml
@@ -67,8 +67,7 @@ jobs:
           # Export with suppressed output
           wrangler d1 export $DB_NAME \
             --output="backups/api_${DB_NAME}_full_${{ steps.date.outputs.TIMESTAMP }}.sql" \
-            --remote \
-            --env $ENVIRONMENT > /dev/null 2>&1
+            --remote > /dev/null 2>&1
 
           # Only report success/failure, not data
           if [ $? -eq 0 ]; then
@@ -96,8 +95,7 @@ jobs:
           # Export with suppressed output
           wrangler d1 export $DB_NAME \
             --output="backups/scores_${DB_NAME}_full_${{ steps.date.outputs.TIMESTAMP }}.sql" \
-            --remote \
-            --env $ENVIRONMENT > /dev/null 2>&1
+            --remote > /dev/null 2>&1
 
           # Only report success/failure, not data
           if [ $? -eq 0 ]; then
@@ -126,10 +124,10 @@ jobs:
 
           # Get table counts only - no data is logged
           # Redirect stderr to /dev/null to avoid logging any errors that might contain data
-          API_USERS=$(wrangler d1 execute $API_DB --command "SELECT COUNT(*) as count FROM users;" --remote --env $ENVIRONMENT 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*' || echo "0")
-          API_SYNC=$(wrangler d1 execute $API_DB --command "SELECT COUNT(*) as count FROM sync_data;" --remote --env $ENVIRONMENT 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*' || echo "0")
+          API_USERS=$(wrangler d1 execute $API_DB --command "SELECT COUNT(*) as count FROM users;" --remote 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*' || echo "0")
+          API_SYNC=$(wrangler d1 execute $API_DB --command "SELECT COUNT(*) as count FROM sync_data;" --remote 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*' || echo "0")
 
-          SCORES_COUNT=$(wrangler d1 execute $SCORES_DB --command "SELECT COUNT(*) as count FROM scores;" --remote --env $ENVIRONMENT 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*' || echo "0")
+          SCORES_COUNT=$(wrangler d1 execute $SCORES_DB --command "SELECT COUNT(*) as count FROM scores;" --remote 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*' || echo "0")
 
           # Only output counts, no actual data
           echo "::add-mask::$API_USERS"


### PR DESCRIPTION
## Summary

This PR fixes the failing scheduled backup workflow by removing the incorrect `--env` flag from wrangler d1 commands.

## Problem

The backup workflow was failing with exit code 1 because:
- The `--env` flag was being used incorrectly with `wrangler d1 export` and `wrangler d1 execute` commands
- This flag is meant for selecting wrangler.toml environment configurations when running from a project directory
- Since the workflow runs from the repository root and directly specifies database names, the flag is not needed

## Solution

- Removed `--env $ENVIRONMENT` from all wrangler d1 commands in the workflow
- The workflow already determines the correct database names based on the environment (production/staging)
- The database names are passed directly to wrangler commands

## Testing

To test this fix:
1. Go to [Actions → Scheduled D1 Database Backup](https://github.com/pezware/mirubato/actions/workflows/scheduled-backup.yml)
2. Click "Run workflow"
3. Select environment (production or staging)
4. The workflow should now complete successfully

## Changes

- Removed `--env` flag from `wrangler d1 export` commands (lines 68-70, 96-98)
- Removed `--env` flag from `wrangler d1 execute` commands (lines 127-130)