### PR TITLE
fix: correct timezone handling for 'Practiced today' display

### DIFF
--- a/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
+++ b/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { formatDistanceToNow } from 'date-fns'
+import { formatDistanceToNow, isToday } from 'date-fns'
 import { useTranslation } from 'react-i18next'
 import { formatDuration } from '@/utils/dateUtils'
 import { RepertoireItem, RepertoireStatus } from '@/api/repertoire'
@@ -58,6 +58,7 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
 
   // Determine if needs attention (not practiced in 5+ days)
   const lastPractice = item.lastPracticed || item.recentPractice?.[0]?.timestamp
+  const lastPracticeDate = lastPractice ? new Date(lastPractice) : null
   const daysSinceLastPractice = lastPractice
     ? Math.floor((Date.now() - lastPractice) / (1000 * 60 * 60 * 24))
     : null
@@ -65,7 +66,7 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
   const needsAttention = daysSinceLastPractice && daysSinceLastPractice >= 5
 
   // Determine status indicator color
-  const isActive = daysSinceLastPractice === 0
+  const isActive = lastPracticeDate ? isToday(lastPracticeDate) : false
   const indicatorClass = isActive
     ? 'bg-green-500'
     : needsAttention
@@ -73,10 +74,10 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
       : 'bg-gray-300'
 
   // Format last practice time
-  const lastPracticeText = lastPractice
-    ? daysSinceLastPractice === 0
+  const lastPracticeText = lastPracticeDate
+    ? isToday(lastPracticeDate)
       ? t('repertoire:practicedToday')
-      : formatDistanceToNow(new Date(lastPractice), { addSuffix: true })
+      : formatDistanceToNow(lastPracticeDate, { addSuffix: true })
     : t('repertoire:notPracticedYet')
 
   // Calculate total practice time
@@ -112,7 +113,7 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
                 >
                   {lastPracticeText}
                 </span>
-                {daysSinceLastPractice === 0 && recentSessionDuration > 0 && (
+                {isActive && recentSessionDuration > 0 && (
                   <>
                     <span>•</span>
                     <span>{formatDuration(recentSessionDuration)}</span>


### PR DESCRIPTION
## Summary
- Replace simple day calculation with proper isToday() from date-fns
- Fixes one-day offset issue where yesterday's practice showed as "Practiced today"
- Ensures consistent timezone handling across the application

## Problem
The issue was in the FocusedRepertoireItem component where it calculated whether a piece was practiced today using a simple mathematical calculation that doesn't account for timezone boundaries.

This could result in incorrect day counting when:
1. The practice timestamp was recorded in a different timezone
2. The calculation crosses midnight boundaries  
3. The simple division doesn't account for daylight saving time changes

## Solution
Used the proper isToday() function from date-fns library (already used in PieceDetailView component) to accurately determine if a practice session occurred today.

## Test plan
- [x] Type checking passes
- [x] All unit tests pass (297 tests)
- [ ] Manual testing with different timezones
- [ ] Verify "Practiced today" shows correctly for today's sessions
- [ ] Verify yesterday's sessions no longer show as "Practiced today"

Fixes #263

🤖 Generated with [Claude Code](https://claude.ai/code)