### PR TITLE
fix: capitalize time-related text in UI for consistency

### DIFF
--- a/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
+++ b/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { formatDistanceToNow, isToday } from 'date-fns'
 import { useTranslation } from 'react-i18next'
-import { formatDuration } from '@/utils/dateUtils'
+import { formatDuration, capitalizeTimeString } from '@/utils/dateUtils'
 import { toTitleCase } from '@/utils/textFormatting'
 import { RepertoireItem, RepertoireStatus } from '@/api/repertoire'
 import { Goal } from '@/api/goals'
@@ -78,7 +78,9 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
   const lastPracticeText = lastPracticeDate
     ? isToday(lastPracticeDate)
       ? t('repertoire:practicedToday')
-      : formatDistanceToNow(lastPracticeDate, { addSuffix: true })
+      : capitalizeTimeString(
+          formatDistanceToNow(lastPracticeDate, { addSuffix: true })
+        )
     : t('repertoire:notPracticedYet')
 
   // Calculate total practice time

--- a/frontendv2/src/components/repertoire/PieceDetailView.tsx
+++ b/frontendv2/src/components/repertoire/PieceDetailView.tsx
@@ -13,7 +13,7 @@ import {
 import Button from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { Select } from '@/components/ui/Select'
-import { formatDuration } from '@/utils/dateUtils'
+import { formatDuration, capitalizeTimeString } from '@/utils/dateUtils'
 import { toTitleCase } from '@/utils/textFormatting'
 import { RepertoireStatus } from '@/api/repertoire'
 import { EditPieceModal } from '../practice-reports/EditPieceModal'
@@ -116,7 +116,9 @@ export const PieceDetailView: React.FC<PieceDetailViewProps> = ({
       } else if (isYesterday(date)) {
         lastPracticed = 'Yesterday'
       } else {
-        lastPracticed = formatDistanceToNow(date, { addSuffix: true })
+        lastPracticed = capitalizeTimeString(
+          formatDistanceToNow(date, { addSuffix: true })
+        )
       }
     }
 

--- a/frontendv2/src/utils/dateUtils.ts
+++ b/frontendv2/src/utils/dateUtils.ts
@@ -40,8 +40,45 @@ export function formatRelativeTime(timestamp: number | Date | string): string {
 
   if (diffDays === 0) return 'Today'
   if (diffDays === 1) return 'Yesterday'
-  if (diffDays < 7) return `${diffDays} days ago`
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`
-  return `${Math.floor(diffDays / 365)} years ago`
+  if (diffDays < 7) return `${diffDays} Days Ago`
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} Weeks Ago`
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} Months Ago`
+  return `${Math.floor(diffDays / 365)} Years Ago`
+}
+
+/**
+ * Capitalizes time-related words in a string
+ * Used to fix date-fns formatDistanceToNow output
+ * Example: "about 1 week ago" → "About 1 Week Ago"
+ */
+export function capitalizeTimeString(str: string): string {
+  const wordsToCapitalize = [
+    'about',
+    'less',
+    'over',
+    'almost',
+    'second',
+    'seconds',
+    'minute',
+    'minutes',
+    'hour',
+    'hours',
+    'day',
+    'days',
+    'week',
+    'weeks',
+    'month',
+    'months',
+    'year',
+    'years',
+    'ago',
+  ]
+
+  let result = str
+  wordsToCapitalize.forEach(word => {
+    const regex = new RegExp(`\\b${word}\\b`, 'gi')
+    result = result.replace(regex, word.charAt(0).toUpperCase() + word.slice(1))
+  })
+
+  return result
 }


### PR DESCRIPTION
## Summary
- Fix inconsistent capitalization of time-related text (e.g., "about 1 week ago" → "About 1 Week Ago")  
- Update `formatRelativeTime` function to return properly capitalized strings
- Add `capitalizeTimeString` utility to handle date-fns output formatting

## Problem
The UI showed inconsistent capitalization for time-related text:
- "about" and "week" were lowercase in some places
- Other UI elements used title case

## Solution
1. Updated `formatRelativeTime` in `dateUtils.ts` to return title-cased strings (e.g., "3 Weeks Ago")
2. Created `capitalizeTimeString` utility function to wrap date-fns `formatDistanceToNow` output
3. Applied the wrapper to all `formatDistanceToNow` calls in repertoire components

## Test plan
- [x] All existing tests pass
- [x] Linter passes
- [x] Build succeeds
- [ ] Manual testing: Check repertoire views to confirm proper capitalization
- [ ] Verify time strings like "About 1 Week Ago" appear with consistent title case

Resolves #300

🤖 Generated with [Claude Code](https://claude.ai/code)