### PR TITLE
fix: update Active Pieces count to only include pieces with 'learning' status

### DIFF
--- a/frontendv2/src/components/repertoire/RepertoireView.tsx
+++ b/frontendv2/src/components/repertoire/RepertoireView.tsx
@@ -115,9 +115,9 @@ export default function RepertoireView({ analytics }: RepertoireViewProps) {
       .filter(entry => new Date(entry.timestamp).getTime() > oneWeekAgo)
       .reduce((sum, entry) => sum + entry.duration, 0)
 
-    // Active pieces count - exclude dropped pieces
+    // Active pieces count - only count pieces with 'learning' status
     const activePieces = filteredItems.filter(
-      item => item.status !== 'dropped'
+      item => item.status === 'learning'
     ).length
 
     // Calculate current streak


### PR DESCRIPTION
## Summary
- Updates the Active Pieces count in the Repertoire view to only count pieces with 'learning' status
- Previously counted all non-dropped pieces (planned, learning, working, polished, performance ready)
- This provides a more meaningful metric focused on actively learning pieces

## Changes
- Modified the active pieces calculation in `RepertoireView.tsx` from filtering out `status \!== 'dropped'` to only including `status === 'learning'`

## Test plan
- [x] All existing unit tests pass (344 tests)
- [ ] Manual testing on staging with test data to verify correct counts

Fixes #299

🤖 Generated with [Claude Code](https://claude.ai/code)