### PR TITLE
fix: circle of fifths audio issue #307

### DIFF
--- a/frontendv2/src/components/circle-of-fifths/CircleOfFifths.tsx
+++ b/frontendv2/src/components/circle-of-fifths/CircleOfFifths.tsx
@@ -22,10 +22,6 @@ const CircleOfFifths: React.FC = () => {
     if (isAudioEnabled) {
       musicalAudioService.initialize()
       musicalAudioService.setVolume(volume)
-
-      // Optional: Upgrade to real piano samples for better sound quality
-      // Uncomment the line below to enable piano samples (will load ~1MB of samples)
-      // musicalAudioService.upgradeToSampledPiano()
     }
 
     // Cleanup on unmount


### PR DESCRIPTION
fix #307 
1. Fixed Minor Key Chord Playback
The issue was that the buildChord method was trying to find "Am" in the scale, but the scale only contains "A". I fixed this by stripping the 'm' suffix from minor key names before searching for the root note in the scale.

2. Improved Piano Sound Quality
* Removed synthesis code: Eliminated all FM synthesis configuration to reduce bundle size
* Direct piano sample loading: The service now loads piano samples directly in the initialize() method

3. Additional Improvements:
* Added proper cleanup to prevent audio overlap issues
* Fixed the React hooks dependency warning
