### PR TITLE
fix: remove "Read more" toggle in Music Dictionary

### DIFF
--- a/frontendv2/src/components/dictionary/DictionaryTerm.tsx
+++ b/frontendv2/src/components/dictionary/DictionaryTerm.tsx
@@ -252,10 +252,7 @@ const DictionaryTerm: React.FC<DictionaryTermProps> = ({
 
         {/* Detailed definition */}
         {termEntry.definition?.detailed && (
-          <details className="mt-4">
-            <summary className="cursor-pointer text-sage-600 hover:text-sage-700 font-medium">
-              {t('toolbox:dictionary.readMore')}
-            </summary>
+          <div className="mt-4">
             <div className="mt-2 text-stone-700 space-y-2">
               <p>{sanitizeOutput(termEntry.definition.detailed)}</p>
 
@@ -271,7 +268,7 @@ const DictionaryTerm: React.FC<DictionaryTermProps> = ({
                 </div>
               )}
             </div>
-          </details>
+          </div>
         )}
       </div>
 

--- a/frontendv2/src/locales/de/toolbox.json
+++ b/frontendv2/src/locales/de/toolbox.json
@@ -112,7 +112,6 @@
     "hasReferences": "Hat Referenzen",
     "pronunciation": "Aussprache",
     "etymology": "Etymologie",
-    "readMore": "Mehr lesen",
     "example": "Beispiel",
     "difficulty": {
       "beginner": "Anfänger",

--- a/frontendv2/src/locales/en/toolbox.json
+++ b/frontendv2/src/locales/en/toolbox.json
@@ -112,7 +112,6 @@
     "hasReferences": "Has references",
     "pronunciation": "Pronunciation",
     "etymology": "Etymology",
-    "readMore": "Read more",
     "example": "Example",
     "difficulty": {
       "beginner": "Beginner",

--- a/frontendv2/src/locales/es/toolbox.json
+++ b/frontendv2/src/locales/es/toolbox.json
@@ -112,7 +112,6 @@
     "hasReferences": "Tiene referencias",
     "pronunciation": "Pronunciación",
     "etymology": "Etimología",
-    "readMore": "Leer más",
     "example": "Ejemplo",
     "difficulty": {
       "beginner": "Principiante",

--- a/frontendv2/src/locales/fr/toolbox.json
+++ b/frontendv2/src/locales/fr/toolbox.json
@@ -112,7 +112,6 @@
     "hasReferences": "A des références",
     "pronunciation": "Prononciation",
     "etymology": "Étymologie",
-    "readMore": "Lire plus",
     "example": "Exemple",
     "difficulty": {
       "beginner": "Débutant",

--- a/frontendv2/src/locales/zh-CN/toolbox.json
+++ b/frontendv2/src/locales/zh-CN/toolbox.json
@@ -112,7 +112,6 @@
     "hasReferences": "有参考资料",
     "pronunciation": "发音",
     "etymology": "词源",
-    "readMore": "阅读更多",
     "example": "示例",
     "difficulty": {
       "beginner": "初学者",

--- a/frontendv2/src/locales/zh-TW/toolbox.json
+++ b/frontendv2/src/locales/zh-TW/toolbox.json
@@ -112,7 +112,6 @@
     "hasReferences": "有參考資料",
     "pronunciation": "發音",
     "etymology": "詞源",
-    "readMore": "閱讀更多",
     "example": "範例",
     "difficulty": {
       "beginner": "初學者",


### PR DESCRIPTION
## Summary
- Remove the collapsible "Read more" toggle from dictionary term entries
- Display detailed definition and usage examples directly without requiring user interaction
- Clean up unused translation keys from all locale files

## Motivation
As reported in #318, the "Read more" toggle was hiding very little content, making the extra click unnecessary. This change improves the user experience by showing all content immediately.

## Changes
1. Updated `DictionaryTerm.tsx` to remove `<details>` and `<summary>` elements
2. Content that was previously hidden (detailed definition and usage examples) is now always visible
3. Removed the unused "readMore" translation key from all 6 locale files

## Test Plan
- [x] TypeScript compilation passes
- [x] All unit tests pass (353 tests)
- [x] Manually verified the dictionary displays correctly without the toggle

Fixes #318

🤖 Generated with [Claude Code](https://claude.ai/code)