### PR TITLE
fix: show piece input fields when editing entries without pieces (#295)

### DIFF
--- a/frontendv2/src/components/ManualEntryForm.tsx
+++ b/frontendv2/src/components/ManualEntryForm.tsx
@@ -69,7 +69,9 @@ export default function ManualEntryForm({
     entry?.mood
   )
   const [pieces, setPieces] = useState(
-    entry?.pieces || initialPieces || [{ title: '', composer: '' }]
+    entry?.pieces && entry.pieces.length > 0
+      ? entry.pieces
+      : initialPieces || [{ title: '', composer: '' }]
   )
   const [techniques, setTechniques] = useState<string[]>(
     entry?.techniques || []


### PR DESCRIPTION
## Summary

- Fixed issue where piece input fields were missing when editing logbook entries that were created without specifying any pieces
- Changed pieces state initialization to explicitly check for empty arrays  
- Ensures at least one empty piece input is always shown in edit mode

## The Problem

When users created logbook entries without specifying any pieces, the `entry.pieces` array would be empty (`[]`). When editing such entries later, no piece input fields would be displayed because:

1. The empty array `[]` is truthy in JavaScript
2. The code would use this empty array instead of falling back to the default `[{ title: '', composer: '' }]`
3. The render logic `pieces.slice(0, 1).map(...)` on an empty array renders nothing

## The Solution

Updated the pieces state initialization in `ManualEntryForm.tsx`:

```typescript
// Before
const [pieces, setPieces] = useState(
  entry?.pieces || initialPieces || [{ title: '', composer: '' }]
)

// After  
const [pieces, setPieces] = useState(
  (entry?.pieces && entry.pieces.length > 0) 
    ? entry.pieces 
    : (initialPieces || [{ title: '', composer: '' }])
)
```

## Test plan

- [x] Create a new logbook entry without specifying any pieces
- [x] Edit that entry - piece input fields should now be visible
- [x] Verify existing entries with pieces still work correctly
- [x] Verify new entries still work correctly
- [x] All unit tests pass

Fixes #295

🤖 Generated with [Claude Code](https://claude.ai/code)