### PR TITLE
fix: edit notes button not responding in piece detail view (#339)

### DIFF
--- a/frontendv2/src/components/repertoire/RepertoireView.tsx
+++ b/frontendv2/src/components/repertoire/RepertoireView.tsx
@@ -306,38 +306,69 @@ export default function RepertoireView({ analytics }: RepertoireViewProps) {
     }))
 
     return (
-      <PieceDetailView
-        item={selectedPiece}
-        sessions={practiceSessions}
-        onBack={() => setSelectedPiece(null)}
-        onLogPractice={() => {
-          setManualEntryPiece({
-            title: selectedPiece.scoreTitle,
-            composer: selectedPiece.scoreComposer,
-            scoreId: selectedPiece.scoreId,
-          })
-          setSelectedPiece(null)
-          setShowManualEntry(true)
-        }}
-        onEditNotes={() => {
-          setEditingPieceNotes(selectedPiece)
-        }}
-        onEditSession={sessionId => {
-          setEditingSessionId(sessionId)
-        }}
-        onStatusChange={async newStatus => {
-          await updateRepertoireStatus(selectedPiece.scoreId, newStatus)
-          // Refresh the selected piece data
-          const updatedItem = repertoire.get(selectedPiece.scoreId)
-          if (updatedItem) {
-            setSelectedPiece({
-              ...selectedPiece,
-              ...updatedItem,
-              status: newStatus,
+      <>
+        <PieceDetailView
+          item={selectedPiece}
+          sessions={practiceSessions}
+          onBack={() => setSelectedPiece(null)}
+          onLogPractice={() => {
+            setManualEntryPiece({
+              title: selectedPiece.scoreTitle,
+              composer: selectedPiece.scoreComposer,
+              scoreId: selectedPiece.scoreId,
             })
-          }
-        }}
-      />
+            setSelectedPiece(null)
+            setShowManualEntry(true)
+          }}
+          onEditNotes={() => {
+            setEditingPieceNotes(selectedPiece)
+          }}
+          onEditSession={sessionId => {
+            setEditingSessionId(sessionId)
+          }}
+          onStatusChange={async newStatus => {
+            await updateRepertoireStatus(selectedPiece.scoreId, newStatus)
+            // Refresh the selected piece data
+            const updatedItem = repertoire.get(selectedPiece.scoreId)
+            if (updatedItem) {
+              setSelectedPiece({
+                ...selectedPiece,
+                ...updatedItem,
+                status: newStatus,
+              })
+            }
+          }}
+        />
+
+        {/* Edit Notes Modal - Available in piece detail view */}
+        {editingPieceNotes && (
+          <EditNotesModal
+            isOpen={true}
+            onClose={() => setEditingPieceNotes(null)}
+            pieceTitle={editingPieceNotes.scoreTitle}
+            currentNotes={editingPieceNotes.personalNotes || ''}
+            currentLinks={editingPieceNotes.referenceLinks || []}
+            onSave={async (notes, links) => {
+              await updateRepertoire(editingPieceNotes.scoreId, {
+                personalNotes: notes,
+                referenceLinks: links,
+              })
+              setEditingPieceNotes(null)
+              // Update the selected piece with new notes
+              if (
+                selectedPiece &&
+                selectedPiece.scoreId === editingPieceNotes.scoreId
+              ) {
+                setSelectedPiece({
+                  ...selectedPiece,
+                  personalNotes: notes,
+                  referenceLinks: links,
+                })
+              }
+            }}
+          />
+        )}
+      </>
     )
   }
 


### PR DESCRIPTION
Fixed the Edit Notes button that was not working when viewing piece details in the repertoire tab. The issue was that the EditNotesModal component was only rendered in the main repertoire list view but not when viewing individual piece details.

Changes:
- Modified RepertoireView.tsx to render EditNotesModal alongside PieceDetailView
- Added logic to update the selected piece's notes after saving
- Ensured users stay on the piece detail page when editing notes (maintaining behavior from PR #329)

Testing:
- Tested navigating to piece detail view and clicking Edit button
- Verified modal opens and saves correctly
- Confirmed user stays on detail page after save
- All existing tests pass

Fixes #339 
Fixes #297 

🤖 Generated with [Claude Code](https://claude.ai/code)