### PR TITLE
feat: add composer search autocomplete to Add Custom Piece modal

### DIFF
--- a/frontendv2/src/locales/de/common.json
+++ b/frontendv2/src/locales/de/common.json
@@ -174,8 +174,8 @@
     "reports": "Berichte",
     "scores": "Noten",
     "settings": "Einstellungen",
-    "toolbox": "Werkzeugkasten",
-    "timer": "Timer"
+    "timer": "Timer",
+    "toolbox": "Werkzeugkasten"
   },
   "next": "Weiter",
   "no": "Nein",

--- a/frontendv2/src/locales/de/logbook.json
+++ b/frontendv2/src/locales/de/logbook.json
@@ -42,6 +42,7 @@
       "selectTechniques": "Geübte Techniken auswählen"
     },
     "techniques": "Techniken",
+    "time": "Zeit",
     "type": "Art",
     "typeOptions": {
       "lesson": "Unterricht",
@@ -50,8 +51,7 @@
       "rehearsal": "Probe",
       "technique": "Technik"
     },
-    "updateEntry": "Eintrag aktualisieren",
-    "time": "Zeit"
+    "updateEntry": "Eintrag aktualisieren"
   },
   "filters": {
     "allTime": "Gesamte Zeit",

--- a/frontendv2/src/locales/de/repertoire.json
+++ b/frontendv2/src/locales/de/repertoire.json
@@ -16,6 +16,9 @@
   "allScoresInRepertoire": "Alle verfügbaren Partituren sind bereits in Ihrem Repertoire",
   "allTypes": "Alle Typen",
   "alreadyPracticed": "Sie haben bereits {{minutes}} Minuten an diesem Stück geübt",
+  "autocomplete": {
+    "offline": "Offline - zeige deinen Verlauf"
+  },
   "avgSession": "Durchschnittliche Sitzung",
   "cannotDelete": "Stücke mit Übungsverlauf können nicht gelöscht werden",
   "completedGoals": "Abgeschlossene Ziele",
@@ -96,6 +99,7 @@
   "logPractice": "Übung protokollieren",
   "myRepertoire": "Mein Repertoire",
   "needAttention": "Benötigen Aufmerksamkeit",
+  "noComposersFound": "Keine Komponisten gefunden",
   "noGoals": "Keine Ziele",
   "noPracticeSessions": "Noch keine Übungssitzungen",
   "noScoresMatchSearch": "Keine Partituren entsprechen Ihrer Suche",

--- a/frontendv2/src/locales/en/repertoire.json
+++ b/frontendv2/src/locales/en/repertoire.json
@@ -146,8 +146,12 @@
   "composer": "Composer",
   "composerPlaceholder": "e.g. Chopin",
   "titleRequired": "Piece title is required",
-  "delete": "Delete from repertoire",
+  "delete": "Delete from pieces",
   "confirmDelete": "Are you sure you want to delete this piece?",
   "cannotDelete": "Cannot delete pieces with practice history",
-  "deleteSuccess": "Removed from repertoire"
+  "deleteSuccess": "Removed from pieces",
+  "noComposersFound": "No composers found",
+  "autocomplete": {
+    "offline": "Offline - showing your history"
+  }
 }

--- a/frontendv2/src/locales/es/common.json
+++ b/frontendv2/src/locales/es/common.json
@@ -174,8 +174,8 @@
     "reports": "Informes",
     "scores": "Partituras",
     "settings": "Configuración",
-    "toolbox": "Herramientas",
-    "timer": "Temporizador"
+    "timer": "Temporizador",
+    "toolbox": "Herramientas"
   },
   "next": "Siguiente",
   "no": "No",

--- a/frontendv2/src/locales/es/logbook.json
+++ b/frontendv2/src/locales/es/logbook.json
@@ -42,6 +42,7 @@
       "selectTechniques": "Seleccionar técnicas practicadas"
     },
     "techniques": "Técnicas",
+    "time": "Hora",
     "type": "Tipo",
     "typeOptions": {
       "lesson": "Lección",
@@ -50,8 +51,7 @@
       "rehearsal": "Ensayo",
       "technique": "Técnica"
     },
-    "updateEntry": "Actualizar entrada",
-    "time": "Hora"
+    "updateEntry": "Actualizar entrada"
   },
   "filters": {
     "allTime": "Todo el tiempo",

--- a/frontendv2/src/locales/es/repertoire.json
+++ b/frontendv2/src/locales/es/repertoire.json
@@ -16,6 +16,9 @@
   "allScoresInRepertoire": "Todas las partituras disponibles ya están en tu repertorio",
   "allTypes": "Todos los Tipos",
   "alreadyPracticed": "Ya has practicado {{minutes}} minutos en esta pieza",
+  "autocomplete": {
+    "offline": "Sin conexión - mostrando tu historial"
+  },
   "avgSession": "Sesión Promedio",
   "cannotDelete": "No se pueden eliminar piezas con historial de práctica",
   "completedGoals": "Objetivos Completados",
@@ -96,6 +99,7 @@
   "logPractice": "Registrar Práctica",
   "myRepertoire": "Mi Repertorio",
   "needAttention": "Necesitan Atención",
+  "noComposersFound": "No se encontraron compositores",
   "noGoals": "Sin Objetivos",
   "noPracticeSessions": "Aún no hay sesiones de práctica",
   "noScoresMatchSearch": "No hay partituras que coincidan con tu búsqueda",

--- a/frontendv2/src/locales/fr/common.json
+++ b/frontendv2/src/locales/fr/common.json
@@ -174,8 +174,8 @@
     "reports": "Rapports",
     "scores": "Partitions",
     "settings": "Paramètres",
-    "toolbox": "Boîte à outils",
-    "timer": "Chrono"
+    "timer": "Chrono",
+    "toolbox": "Boîte à outils"
   },
   "next": "Suivant",
   "no": "Non",

--- a/frontendv2/src/locales/fr/logbook.json
+++ b/frontendv2/src/locales/fr/logbook.json
@@ -42,6 +42,7 @@
       "selectTechniques": "Sélectionner les techniques pratiquées"
     },
     "techniques": "Techniques",
+    "time": "Heure",
     "type": "Type",
     "typeOptions": {
       "lesson": "Cours",
@@ -50,8 +51,7 @@
       "rehearsal": "Répétition",
       "technique": "Technique"
     },
-    "updateEntry": "Mettre à jour l'entrée",
-    "time": "Heure"
+    "updateEntry": "Mettre à jour l'entrée"
   },
   "filters": {
     "allTime": "Tout le temps",

--- a/frontendv2/src/locales/fr/repertoire.json
+++ b/frontendv2/src/locales/fr/repertoire.json
@@ -16,6 +16,9 @@
   "allScoresInRepertoire": "Toutes les partitions disponibles sont déjà dans votre répertoire",
   "allTypes": "Tous les types",
   "alreadyPracticed": "Vous avez déjà pratiqué {{minutes}} minutes sur cette pièce",
+  "autocomplete": {
+    "offline": "Hors ligne - affichage de votre historique"
+  },
   "avgSession": "Session moyenne",
   "cannotDelete": "Impossible de supprimer les pièces avec un historique de pratique",
   "completedGoals": "Objectifs Complétés",
@@ -96,6 +99,7 @@
   "logPractice": "Enregistrer la pratique",
   "myRepertoire": "Mon Répertoire",
   "needAttention": "Nécessitent une attention",
+  "noComposersFound": "Aucun compositeur trouvé",
   "noGoals": "Aucun Objectif",
   "noPracticeSessions": "Aucune session de pratique pour le moment",
   "noScoresMatchSearch": "Aucune partition ne correspond à votre recherche",

--- a/frontendv2/src/locales/zh-CN/common.json
+++ b/frontendv2/src/locales/zh-CN/common.json
@@ -174,8 +174,8 @@
     "reports": "报告",
     "scores": "乐谱",
     "settings": "设置",
-    "toolbox": "工具箱",
-    "timer": "计时"
+    "timer": "计时",
+    "toolbox": "工具箱"
   },
   "next": "下一个",
   "no": "否",

--- a/frontendv2/src/locales/zh-CN/logbook.json
+++ b/frontendv2/src/locales/zh-CN/logbook.json
@@ -42,6 +42,7 @@
       "selectTechniques": "选择练习的技巧"
     },
     "techniques": "技巧",
+    "time": "时间",
     "type": "类型",
     "typeOptions": {
       "lesson": "课程",
@@ -50,8 +51,7 @@
       "rehearsal": "排练",
       "technique": "技巧"
     },
-    "updateEntry": "更新记录",
-    "time": "时间"
+    "updateEntry": "更新记录"
   },
   "filters": {
     "allTime": "全部时间",

--- a/frontendv2/src/locales/zh-CN/repertoire.json
+++ b/frontendv2/src/locales/zh-CN/repertoire.json
@@ -16,6 +16,9 @@
   "allScoresInRepertoire": "所有可用的乐谱都已在您的曲目库中",
   "allTypes": "所有类型",
   "alreadyPracticed": "您已经在这首乐曲上练习了 {{minutes}} 分钟",
+  "autocomplete": {
+    "offline": "离线 - 显示您的历史记录"
+  },
   "avgSession": "平均练习时长",
   "cannotDelete": "无法删除有练习记录的曲目",
   "completedGoals": "已完成的目标",
@@ -96,6 +99,7 @@
   "logPractice": "记录练习",
   "myRepertoire": "我的曲目库",
   "needAttention": "需要关注",
+  "noComposersFound": "找不到作曲家",
   "noGoals": "无目标",
   "noPracticeSessions": "尚无练习记录",
   "noScoresMatchSearch": "没有符合您搜索的乐谱",

--- a/frontendv2/src/locales/zh-TW/common.json
+++ b/frontendv2/src/locales/zh-TW/common.json
@@ -174,8 +174,8 @@
     "reports": "報表",
     "scores": "樂譜",
     "settings": "設定",
-    "toolbox": "工具箱",
-    "timer": "計時"
+    "timer": "計時",
+    "toolbox": "工具箱"
   },
   "next": "下一頁",
   "no": "否",

--- a/frontendv2/src/locales/zh-TW/logbook.json
+++ b/frontendv2/src/locales/zh-TW/logbook.json
@@ -42,6 +42,7 @@
       "selectTechniques": "選擇練習的技巧"
     },
     "techniques": "技巧",
+    "time": "時間",
     "type": "類型",
     "typeOptions": {
       "lesson": "課程",
@@ -50,8 +51,7 @@
       "rehearsal": "排練",
       "technique": "技巧"
     },
-    "updateEntry": "更新記錄",
-    "time": "時間"
+    "updateEntry": "更新記錄"
   },
   "filters": {
     "allTime": "全部時間",

--- a/frontendv2/src/locales/zh-TW/repertoire.json
+++ b/frontendv2/src/locales/zh-TW/repertoire.json
@@ -16,6 +16,9 @@
   "allScoresInRepertoire": "所有可用的樂譜都已在您的曲目庫中",
   "allTypes": "所有類型",
   "alreadyPracticed": "您已經在這首樂曲上練習了 {{minutes}} 分鐘",
+  "autocomplete": {
+    "offline": "離線 - 顯示您的歷史記錄"
+  },
   "avgSession": "平均練習時長",
   "cannotDelete": "無法刪除有練習記錄的曲目",
   "completedGoals": "已完成的目標",
@@ -96,6 +99,7 @@
   "logPractice": "記錄練習",
   "myRepertoire": "我的曲目庫",
   "needAttention": "需要關注",
+  "noComposersFound": "找不到作曲家",
   "noGoals": "無目標",
   "noPracticeSessions": "尚無練習記錄",
   "noScoresMatchSearch": "沒有符合您搜尋的樂譜",


### PR DESCRIPTION
## Summary
- Adds composer search functionality to the "Add Custom Piece" modal in the repertoire section
- Implements autocomplete that searches both user's practice history and API for composer suggestions
- Provides a consistent experience with the existing composer search in the "Add Entry" feature

## Changes
- Replace simple input with `Autocomplete` component for composer field
- Use `useAutocomplete` hook with `type: 'composer'` and `minLength: 2`
- Search user's logbook history and API endpoint `/api/autocomplete/composers`
- Show suggestions after typing 2+ characters
- Add offline indicator when API is unavailable
- Maintain title case formatting on blur
- Add and translate new i18n keys for all supported languages

## Screenshots
\![image](https://github.com/user-attachments/assets/screenshot-placeholder)

## Testing
- [x] Composer autocomplete triggers after 2 characters
- [x] Shows suggestions from both logbook history and API
- [x] Works offline (shows only local history)
- [x] Title case formatting on blur still works
- [x] All translations added and verified
- [x] TypeScript compilation passes
- [x] Pre-commit hooks pass

## Related Issue
Fixes #267

🤖 Generated with [Claude Code](https://claude.ai/code)