### PR TITLE
fix: narrow Initial Status dropdown width on mobile in AddToRepertoireModal

### DIFF
--- a/frontendv2/src/components/repertoire/AddToRepertoireModal.tsx
+++ b/frontendv2/src/components/repertoire/AddToRepertoireModal.tsx
@@ -438,7 +438,7 @@ export function AddToRepertoireModal({
                 setSelectedStatus(value as keyof RepertoireStatus)
               }
               options={statusOptions}
-              className="w-full max-w-xs sm:max-w-none"
+              className="w-32 sm:w-full"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- Fixed Initial Status dropdown being too wide on mobile devices
- Changed dropdown width from `w-full max-w-xs` (320px) to `w-32` (128px) on mobile
- Maintains full width on desktop with `sm:w-full`

## Problem
The Initial Status dropdown in the AddToRepertoireModal was still too wide on mobile after PR #343. The `max-w-xs` class was setting a maximum width of 320px, which is too wide for many mobile screens.

## Solution
Applied the same narrow width pattern used in PieceDetailView:
- Mobile: fixed width of 128px (`w-32`)
- Desktop: full width of container (`w-full`)

This matches the pattern successfully applied to other dropdowns in PR #343.

## Related Issues
- Fixes #340

## Screenshots
Mobile view now shows the dropdown with appropriate width that doesn't overflow the modal.

## Test Plan
1. Open the AddToRepertoireModal on a mobile device
2. Verify the Initial Status dropdown fits within the modal without horizontal scrolling
3. Verify desktop view still shows full-width dropdown