### PR TITLE
fix: remove magic link exposure and fix production deployment config

### DIFF
--- a/dictionary/src/routes/admin-portal.ts
+++ b/dictionary/src/routes/admin-portal.ts
@@ -570,12 +570,11 @@ adminPortal.get('/', c => {
                     throw new Error(result.error?.message || 'Failed to send magic link');
                 }
                 
-                // For demo purposes, show the magic link (in production, this would be emailed)
+                // Show success message
                 messageDiv.innerHTML = \`
                     <div class="alert success">
-                        <strong>Magic link generated!</strong><br>
-                        <p style="margin-top: 8px;">In production, this would be sent to your email. For now, click the link below:</p>
-                        <a href="\${result.data.magicLink}" style="color: var(--morandi-sage-600); word-break: break-all;">Open Magic Link</a>
+                        <strong>Magic link sent!</strong><br>
+                        <p style="margin-top: 8px;">Please check your email for the sign-in link.</p>
                     </div>
                 \`;
             } catch (error) {

--- a/dictionary/src/services/email.ts
+++ b/dictionary/src/services/email.ts
@@ -61,14 +61,12 @@ export class EmailService {
 
     // Check if RESEND_API_KEY is configured
     if (!this.env.RESEND_API_KEY) {
-      // In staging, log the magic link for testing
+      // In staging, log that email service is not configured
       if (this.env.ENVIRONMENT === 'staging') {
         console.log(
-          `[STAGING] No RESEND_API_KEY configured. Magic link for ${email}: ${magicLink}`
+          `[STAGING] No RESEND_API_KEY configured. Cannot send email to ${email}.`
         )
-        throw new Error(
-          'Email service not configured. Check server logs for magic link.'
-        )
+        throw new Error('Email service not configured. Please contact support.')
       }
       throw new Error('Email service not configured')
     }
@@ -85,12 +83,12 @@ export class EmailService {
     } catch (error) {
       console.error('Failed to send email via Resend:', error)
 
-      // In staging, provide the magic link in error message
+      // In staging, log the error but don't expose the magic link
       if (this.env.ENVIRONMENT === 'staging') {
         console.log(
-          `[STAGING] Email failed. Magic link for ${email}: ${magicLink}`
+          `[STAGING] Email failed for ${email}. Check server logs for details.`
         )
-        throw new Error(`Email service error. Magic link: ${magicLink}`)
+        throw new Error(`Email service error. Please contact support.`)
       }
       throw error
     }

--- a/dictionary/wrangler.toml
+++ b/dictionary/wrangler.toml
@@ -8,48 +8,8 @@ account_id = "1362434665780520e89f9f06b1057d24"
 [build]
 command = "pnpm run build"
 
-# Production configuration (default - no env flag needed)
-vars = { QUALITY_THRESHOLD = "80", CACHE_TTL = "86400", ENVIRONMENT = "production", API_SERVICE_URL = "https://api.mirubato.com", FRONTEND_URL = "https://mirubato.com", CORS_ORIGIN = "https://mirubato.com,https://www.mirubato.com", SEED_ENABLED = "true", SEED_DAILY_TOKEN_BUDGET = "5000", SEED_PRIORITY_THRESHOLD = "8", SEED_BATCH_SIZE = "5", QUALITY_MIN_THRESHOLD = "85" }
-routes = [
-  { pattern = "dictionary.mirubato.com", custom_domain = true }
-]
-
-# Scheduled triggers for production
-[triggers]
-crons = ["0 2,8,14,20 * * *", "0 0 * * *"]  # Seed processing at 2,8,14,20 UTC; Daily cleanup at midnight
-
-# Observability
-[observability.logs]
-enabled = true
-
-# AI binding for Cloudflare Workers AI
-[ai]
-binding = "AI"
-
-# Queue for batch processing
-[[queues.consumers]]
-queue = "dictionary-processing"
-max_batch_size = 10
-max_batch_timeout = 30
-max_retries = 3
-dead_letter_queue = "dictionary-processing-dlq"
-
-[[d1_databases]]
-binding = "DB"
-database_name = "mirubato-dictionary-production"
-database_id = "1cc0df2f-aac5-41a9-b6d5-405f7d40b740"
-
-[[r2_buckets]]
-binding = "STORAGE"
-bucket_name = "mirubato-dictionary-production"
-
-[[kv_namespaces]]
-binding = "CACHE"
-id = "598693e0de544dd9858a724ecbc556ba"
-
-[[queues.producers]]
-binding = "BATCH_QUEUE"
-queue = "dictionary-processing"
+# Note: Production configuration is in [env.production] section below
+# Default deployment without --env flag is not recommended
 
 # Staging configuration
 [env.staging]


### PR DESCRIPTION
## Summary
- Remove magic link display from admin portal UI (critical security fix)
- Fix wrangler.toml to prevent staging build token in production
- Remove magic link from error messages in staging logs

## Issues Fixed
1. **Security Issue**: Magic link was being displayed in the UI in both staging and production environments
2. **Deployment Issue**: Production was using staging build token, causing emails to contain staging URLs

## Changes
- Updated  to remove magic link display
- Modified  to remove default production config (forces explicit environment deployment)
- Updated  to remove magic link from error messages

## Testing
- TypeScript checks pass
- All unit tests pass
- Ready for staging deployment via Cloudflare builder

## Deployment Notes
- PR will trigger automatic staging deployment
- After verifying staging works correctly, merge to main for production deployment