### PR TITLE
fix: update Wikipedia URL scanner to check for 404s using API

### DIFF
--- a/dictionary/src/routes/admin-portal.ts
+++ b/dictionary/src/routes/admin-portal.ts
@@ -1558,7 +1558,13 @@ adminPortal.get('/', c => {
                                             <div class="queue-item-term">\${entry.term} (\${entry.type})</div>
                                             <div class="queue-item-meta">
                                                 Current: <code>\${entry.current_url}</code><br>
-                                                Suggested: <code>\${entry.suggested_url}</code>
+                                                Suggested: <code>\${entry.suggested_url}</code><br>
+                                                Reason: <span class="text-rose">\${entry.reason || 'URL mismatch'}</span>
+                                                \${entry.suggestions && entry.suggestions.length > 1 ? 
+                                                    '<br>Other suggestions: ' + entry.suggestions.slice(1, 3).map(s => 
+                                                        '<code>' + s.title + '</code>'
+                                                    ).join(', ') : ''
+                                                }
                                             </div>
                                         </div>
                                         <button class="button secondary" onclick="fixSingleWikipediaUrl('\${entry.id}')">


### PR DESCRIPTION
## Summary
- Replace pattern-based checking with actual Wikipedia API validation
- Use validateWikipediaUrl to check if URLs return 404
- Search for correct URLs using getWikipediaSuggestions for invalid links
- Update fix endpoints to validate new URLs before applying
- Display reason and suggestions in admin portal UI

## Issues Fixed
Fixes #316 - Wikipedia URL cleanup not finding invalid links like "third scale degree"

## Changes
1. **Updated scan endpoint** (`/wikipedia/scan`):
   - Now uses `validateWikipediaUrl` to check if each Wikipedia URL actually exists (returns 200, not 404)
   - For 404s, uses `getWikipediaSuggestions` to search Wikipedia for the correct URL
   - Returns the reason ("URL returns 404") and up to 3 suggestions from Wikipedia

2. **Enhanced fix endpoints** (`/wikipedia/fix` and `/wikipedia/fix-all`):
   - Validates suggested URLs before applying them
   - If the generated URL is also invalid, tries Wikipedia search suggestions
   - Only updates entries with valid replacement URLs

3. **Updated admin portal UI**:
   - Displays the reason why a URL needs fixing
   - Shows alternative suggestions from Wikipedia search when available

## How it works
1. Scans all dictionary entries with Wikipedia URLs
2. Checks each URL using Wikipedia API (not just pattern matching)
3. For 404s, searches Wikipedia for the correct article
4. Presents invalid URLs with suggested fixes

This will now properly detect entries like "third scale degree" where the URL returns 404 and suggest valid alternatives.

## Testing
- All existing tests pass ✅
- Pre-commit hooks pass ✅
- TypeScript checks pass ✅

🤖 Generated with [Claude Code](https://claude.ai/code)