### PR TITLE
fix: make time picker hint text more concise

### DIFF
--- a/frontendv2/src/locales/de/common.json
+++ b/frontendv2/src/locales/de/common.json
@@ -268,7 +268,7 @@
   },
   "timePicker": {
     "selectPracticeTime": "Übungszeit Auswählen",
-    "hint": "Inneren Bereich für Stunden ziehen • Äußeren Ring für Minuten anklicken",
+    "hint": "Inneren Kreis für Stunde, äußeren Kreis für Minute klicken",
     "confirmTime": "Zeit Bestätigen",
     "clickToTypeManually": "Klicken Sie, um die Zeit manuell einzugeben"
   },

--- a/frontendv2/src/locales/en/common.json
+++ b/frontendv2/src/locales/en/common.json
@@ -270,7 +270,7 @@
   },
   "timePicker": {
     "selectPracticeTime": "Select Practice Time",
-    "hint": "Drag inner area for hours • Click outer ring for minutes",
+    "hint": "Click inner circle for hour, outer circle for minute",
     "confirmTime": "Confirm Time",
     "clickToTypeManually": "Click to type time manually"
   },

--- a/frontendv2/src/locales/es/common.json
+++ b/frontendv2/src/locales/es/common.json
@@ -268,7 +268,7 @@
   },
   "timePicker": {
     "selectPracticeTime": "Seleccionar Hora de Práctica",
-    "hint": "Arrastra el área interior para las horas • Haz clic en el anillo exterior para los minutos",
+    "hint": "Clic círculo interior para hora, círculo exterior para minuto",
     "confirmTime": "Confirmar Hora",
     "clickToTypeManually": "Haz clic para escribir la hora manualmente"
   },

--- a/frontendv2/src/locales/fr/common.json
+++ b/frontendv2/src/locales/fr/common.json
@@ -268,7 +268,7 @@
   },
   "timePicker": {
     "selectPracticeTime": "Sélectionner l'Heure de Pratique",
-    "hint": "Faites glisser la zone intérieure pour les heures • Cliquez sur l'anneau extérieur pour les minutes",
+    "hint": "Cliquez cercle intérieur pour heure, cercle extérieur pour minute",
     "confirmTime": "Confirmer l'Heure",
     "clickToTypeManually": "Cliquez pour saisir l'heure manuellement"
   },

--- a/frontendv2/src/locales/zh-CN/common.json
+++ b/frontendv2/src/locales/zh-CN/common.json
@@ -268,7 +268,7 @@
   },
   "timePicker": {
     "selectPracticeTime": "选择练习时间",
-    "hint": "拖动内圈设置小时 • 点击外圈设置分钟",
+    "hint": "点击内圈选择小时，外圈选择分钟",
     "confirmTime": "确认时间",
     "clickToTypeManually": "点击手动输入时间"
   },

--- a/frontendv2/src/locales/zh-TW/common.json
+++ b/frontendv2/src/locales/zh-TW/common.json
@@ -268,7 +268,7 @@
   },
   "timePicker": {
     "selectPracticeTime": "選擇練習時間",
-    "hint": "拖曳內圈設定小時 • 點擊外圈設定分鐘",
+    "hint": "點擊內圈選擇小時，外圈選擇分鐘",
     "confirmTime": "確認時間",
     "clickToTypeManually": "點擊以手動輸入時間"
   },


### PR DESCRIPTION
## Summary
- Fixes #378 - Makes the time picker instruction text more concise to fit on a single line
- Updated text from: "Drag inner area for hours • Click outer ring for minutes"
- To: "Click inner circle for hour, outer circle for minute"

## Changes
Updated all 6 language translation files:
- English
- Spanish
- French
- German
- Chinese (Simplified)
- Chinese (Traditional)

## Test plan
- [x] Navigate to Logbook > Add Entry
- [x] Click on the time picker
- [x] Verify the hint text is now on a single line
- [x] Test in different languages to ensure translations are concise

🤖 Generated with [Claude Code](https://claude.ai/code)