### PR TITLE
Enable global add entry button in toolbox and remove status badge backgrounds

### DIFF
--- a/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
+++ b/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
@@ -147,7 +147,7 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
               <div className="flex items-center gap-2 sm:gap-3 text-xs sm:text-sm text-stone-600 flex-wrap min-w-0 flex-1">
                 {/* Status Badge */}
                 <span
-                  className={`px-2 py-0.5 ${status.bg} ${status.color} rounded-full text-xs font-medium flex-shrink-0`}
+                  className={`px-2 py-0.5 ${status.color} rounded-full text-xs font-medium flex-shrink-0`}
                 >
                   {status.label}
                 </span>

--- a/frontendv2/src/components/repertoire/RepertoireCard.tsx
+++ b/frontendv2/src/components/repertoire/RepertoireCard.tsx
@@ -179,7 +179,7 @@ export function RepertoireCard({ item, onEditSession }: RepertoireCardProps) {
               ) : (
                 <button
                   onClick={() => setIsEditingStatus(true)}
-                  className={`px-3 py-1 ${status.bg} ${status.color} rounded-full text-sm font-medium hover:opacity-80 transition-opacity`}
+                  className={`px-3 py-1 ${status.color} rounded-full text-sm font-medium hover:opacity-80 transition-opacity`}
                 >
                   {status.label}
                 </button>

--- a/frontendv2/src/pages/Toolbox.tsx
+++ b/frontendv2/src/pages/Toolbox.tsx
@@ -405,6 +405,7 @@ const Toolbox: React.FC = () => {
 
   return (
     <AppLayout
+      onNewEntry={handleToolboxAdd}
       onTimerClick={() => setShowTimer(true)}
       onToolboxAdd={handleToolboxAdd}
     >


### PR DESCRIPTION
## Summary
- Enable global Add Entry button in Toolbox sidebar view (fixes #390)
- Remove background colors from status badges in Logbook > Pieces list for cleaner UI

## Changes Made

### 1. Global Add Entry Button Fix
- **File**: frontendv2/src/pages/Toolbox.tsx
- **Change**: Added onNewEntry={handleToolboxAdd} prop to AppLayout component
- **Result**: Add Entry button now appears in sidebar when viewing Toolbox, alongside the timer button

### 2. Status Badge Background Removal
- **Files**: 
  - frontendv2/src/components/repertoire/RepertoireCard.tsx
  - frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
- **Change**: Removed background colors from status badge elements
- **Result**: Status badges (Learning, Planned, Polished, etc.) now display only colored text without background colors

## Test plan
- Navigate to Toolbox view - verify Add Entry button appears in sidebar
- Click Add Entry button - verify manual entry form opens
- Navigate to Logbook > Pieces - verify status badges show only colored text (no backgrounds)
- All existing functionality remains unchanged
- Pre-commit hooks and tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)