### PR TITLE
feat: auto-expand default collection with scores in My Collections tab

### DIFF
--- a/frontendv2/src/types/collections.ts
+++ b/frontendv2/src/types/collections.ts
@@ -11,6 +11,7 @@ export interface Collection {
   ownerType: 'user' | 'admin' | 'teacher'
   visibility: 'private' | 'public' | 'unlisted'
   tags: string[]
+  is_default?: boolean // Flag for default "General" collection
   featuredAt?: string | null
   featuredBy?: string | null
   displayOrder?: number | null


### PR DESCRIPTION
## Summary
- Auto-expand user's default collection when visiting the scorebook
- Load and display first 5 scores inline within expanded default collection
- Add loading states and empty collection feedback
- Preserve existing tab structure and navigation patterns

## Changes Made
- **Modified `ScoreBrowser.tsx`**: Added logic to identify, auto-expand, and load scores for default collection
- **Updated `Collection` interface**: Added `is_default` property for type safety
- **Enhanced UX**: Users can now immediately see their scores without additional navigation

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint validation passes
- [x] Unit tests pass
- [x] Pre-commit hooks successful
- [x] Build completes successfully

## Screenshots/Demo
When users visit `/scorebook` and navigate to "My Collections" tab:
- Default collection automatically expands
- First 5 scores display with existing `ScoreListItem` components
- Loading indicator shows while fetching scores
- Empty state message for collections with no scores
- "View Collection" button available for full collection view

Closes #388

🤖 Generated with [Claude Code](https://claude.ai/code)