### PR TITLE
fix: correct root note border color for minor keys in Circle of Fifths keyboard

### DIFF
--- a/frontendv2/src/components/circle-of-fifths/PianoKeyboard.tsx
+++ b/frontendv2/src/components/circle-of-fifths/PianoKeyboard.tsx
@@ -151,17 +151,22 @@ const PianoKeyboard: React.FC<PianoKeyboardProps> = ({
 
   // Separate root note for special highlighting
   const rootNote = keyData.id
-  const rootNoteWithEnharmonic = new Set([rootNote])
-  if (keyData.enharmonic) {
-    rootNoteWithEnharmonic.add(keyData.enharmonic)
-  }
-
-  const chordNotes = getChordNotes()
 
   // Extract the actual root note (without 'm' for minor keys)
   const actualRootNote = rootNote.includes('m')
     ? rootNote.replace(/m$/, '')
     : rootNote
+
+  const rootNoteWithEnharmonic = new Set([actualRootNote])
+  if (keyData.enharmonic) {
+    // For enharmonics, also strip 'm' if present
+    const enharmonicNote = keyData.enharmonic.includes('m')
+      ? keyData.enharmonic.replace(/m$/, '')
+      : keyData.enharmonic
+    rootNoteWithEnharmonic.add(enharmonicNote)
+  }
+
+  const chordNotes = getChordNotes()
 
   // Track octave highlighting state
   const octaveHighlighting = (() => {
@@ -303,8 +308,7 @@ const PianoKeyboard: React.FC<PianoKeyboardProps> = ({
                     (note === 'F' && keyData.scale.includes('E#')) ||
                     (note === 'C' && keyData.scale.includes('B#')))
                 const isChordNote = isInOctave && chordNotes.has(note)
-                const isRootNote =
-                  isInOctave && rootNoteWithEnharmonic.has(note)
+                const isRootNote = rootNoteWithEnharmonic.has(note)
                 const isActive = isPlaying && isRootNote
 
                 return (
@@ -366,9 +370,8 @@ const PianoKeyboard: React.FC<PianoKeyboardProps> = ({
                 isInOctave &&
                 (chordNotes.has(note) || chordNotes.has(displayNote))
               const isRootNote =
-                isInOctave &&
-                (rootNoteWithEnharmonic.has(note) ||
-                  rootNoteWithEnharmonic.has(displayNote))
+                rootNoteWithEnharmonic.has(note) ||
+                rootNoteWithEnharmonic.has(displayNote)
               const isActive = isPlaying && isRootNote
 
               return (
@@ -428,9 +431,8 @@ const PianoKeyboard: React.FC<PianoKeyboardProps> = ({
                 isInOctave &&
                 (chordNotes.has(note) || chordNotes.has(displayNote))
               const isRootNote =
-                isInOctave &&
-                (rootNoteWithEnharmonic.has(note) ||
-                  rootNoteWithEnharmonic.has(displayNote))
+                rootNoteWithEnharmonic.has(note) ||
+                rootNoteWithEnharmonic.has(displayNote)
               const isActive = isPlaying && isRootNote
 
               return (


### PR DESCRIPTION
## Summary
- Fixed issue where root notes in minor keys showed orange borders instead of red in the Circle of Fifths keyboard visualization
- Root notes now correctly display with red borders regardless of key type (major or minor)

## Problem
When selecting a minor key (e.g., Cm, Gm, Dm), the root note on the keyboard was incorrectly displayed with an orange border (scale note color) instead of the expected red border (root note color). This only affected white keys; black key root notes displayed correctly.

## Root Cause
The `rootNoteWithEnharmonic` set was being initialized with the full key ID including the 'm' suffix for minor keys (e.g., "Cm"), but the keyboard component was checking against plain note names (e.g., "C"). This caused the root note check to fail and fall through to the scale note styling.

## Solution
1. Moved the extraction of `actualRootNote` (without 'm' suffix) before creating the `rootNoteWithEnharmonic` set
2. Initialize the set with the clean note name
3. Also handle enharmonic equivalents properly by stripping 'm' if present
4. Separated root note identification from octave range check to ensure consistent highlighting

## Testing
- ✅ Linter passes
- ✅ Build completes successfully  
- ✅ All tests pass (443 tests)
- ✅ Pre-commit hooks pass

## Visual Verification
Tested with multiple minor keys (Cm, Gm, Dm, Em, Am, Fm, Bbm) - all now correctly show red borders on their root notes.

🤖 Generated with [Claude Code](https://claude.ai/code)