### PR TITLE
Fix: Simplify 'Remove from pieces' text to 'Remove' in repertoire

### DIFF
--- a/frontendv2/src/locales/de/repertoire.json
+++ b/frontendv2/src/locales/de/repertoire.json
@@ -165,7 +165,7 @@
   "viewAllSessions": "Alle {{count}} Sitzungen anzeigen",
   "viewDetails": "Details anzeigen",
   "viewScore": "Noten ansehen",
-  "removeFromPieces": "Aus Stücken entfernen",
+  "removeFromPieces": "Entfernen",
   "deleteFromPieces": "Stück löschen",
   "deleteCompletely": "Vollständig löschen",
   "removeConfirmMessage": "Dies entfernt \"{{title}}\" aus Ihren Stücken, während Ihre {{count}} Übungssitzungen erhalten bleiben. Das Stück kann später bei Bedarf wieder hinzugefügt werden.",

--- a/frontendv2/src/locales/en/repertoire.json
+++ b/frontendv2/src/locales/en/repertoire.json
@@ -154,7 +154,7 @@
   "confirmDelete": "Are you sure you want to delete this piece?",
   "cannotDelete": "Cannot delete pieces with practice history",
   "deleteSuccess": "Removed from pieces",
-  "removeFromPieces": "Remove from pieces",
+  "removeFromPieces": "Remove",
   "deleteFromPieces": "Delete from pieces",
   "deleteCompletely": "Delete completely",
   "removeConfirmMessage": "This will remove \"{{title}}\" from your pieces while preserving your {{count}} practice sessions. The piece can be re-added later if needed.",

--- a/frontendv2/src/locales/es/repertoire.json
+++ b/frontendv2/src/locales/es/repertoire.json
@@ -165,7 +165,7 @@
   "viewAllSessions": "Ver todas las {{count}} sesiones",
   "viewDetails": "Ver Detalles",
   "viewScore": "Ver Partitura",
-  "removeFromPieces": "Quitar de piezas",
+  "removeFromPieces": "Quitar",
   "deleteFromPieces": "Eliminar pieza",
   "deleteCompletely": "Eliminar completamente",
   "removeConfirmMessage": "Esto quitará \"{{title}}\" de sus piezas mientras preserva sus {{count}} sesiones de práctica. La pieza puede volver a agregarse más tarde si es necesario.",

--- a/frontendv2/src/locales/fr/repertoire.json
+++ b/frontendv2/src/locales/fr/repertoire.json
@@ -165,7 +165,7 @@
   "viewAllSessions": "Voir toutes les {{count}} sessions",
   "viewDetails": "Voir les détails",
   "viewScore": "Voir la Partition",
-  "removeFromPieces": "Retirer des pièces",
+  "removeFromPieces": "Retirer",
   "deleteFromPieces": "Supprimer la pièce",
   "deleteCompletely": "Supprimer complètement",
   "removeConfirmMessage": "Ceci retirera \"{{title}}\" de vos pièces tout en préservant vos {{count}} sessions de pratique. La pièce peut être rajoutée plus tard si nécessaire.",

--- a/frontendv2/src/locales/zh-CN/repertoire.json
+++ b/frontendv2/src/locales/zh-CN/repertoire.json
@@ -165,7 +165,7 @@
   "viewAllSessions": "查看所有 {{count}} 次练习",
   "viewDetails": "查看详情",
   "viewScore": "查看乐谱",
-  "removeFromPieces": "从曲目中移除",
+  "removeFromPieces": "移除",
   "deleteFromPieces": "删除曲目",
   "deleteCompletely": "完全删除",
   "removeConfirmMessage": "这会将《{{title}}》从您的曲目中移除，同时保留您的 {{count}} 次练习记录。之后可以重新添加此曲目。",

--- a/frontendv2/src/locales/zh-TW/repertoire.json
+++ b/frontendv2/src/locales/zh-TW/repertoire.json
@@ -165,7 +165,7 @@
   "viewAllSessions": "查看所有 {{count}} 次練習",
   "viewDetails": "查看詳情",
   "viewScore": "查看樂譜",
-  "removeFromPieces": "從曲目中移除",
+  "removeFromPieces": "移除",
   "deleteFromPieces": "刪除曲目",
   "deleteCompletely": "完全刪除",
   "removeConfirmMessage": "這會將《{{title}}》從您的曲目中移除，同時保留您的 {{count}} 次練習記錄。之後可以重新添加此曲目。",


### PR DESCRIPTION
## Summary
- Simplified the button text in PieceDetailView component from "Remove from pieces" to just "Remove" for better UI conciseness
- Updated translations across all 6 supported languages

## Changes
- Updated `removeFromPieces` translation key in all language files:
  - English: "Remove from pieces" → "Remove"
  - Spanish: "Quitar de piezas" → "Quitar"
  - French: "Retirer des pièces" → "Retirer"
  - German: "Aus Stücken entfernen" → "Entfernen"
  - Traditional Chinese: "從曲目中移除" → "移除"
  - Simplified Chinese: "从曲目中移除" → "移除"

## Test plan
- [ ] Verify the button text appears correctly in PieceDetailView
- [ ] Test with different languages to ensure translations are correct
- [ ] Confirm modal title and button text also use the simplified version

🤖 Generated with [Claude Code](https://claude.ai/code)