### PR TITLE
fix: normalize piece/composer names and show top 5 in analytics

### DIFF
--- a/frontendv2/src/components/practice-reports/views/AnalyticsView.tsx
+++ b/frontendv2/src/components/practice-reports/views/AnalyticsView.tsx
@@ -84,8 +84,9 @@ export default function AnalyticsView({ analytics }: AnalyticsViewProps) {
               {t('reports:analytics.topPieces')}
             </h3>
             <DistributionPie
-              data={analytics.distributionData?.byPiece?.slice(0, 10) || []}
+              data={analytics.distributionData?.byPiece || []}
               type="doughnut"
+              maxItems={5}
             />
           </div>
           <div>
@@ -93,8 +94,9 @@ export default function AnalyticsView({ analytics }: AnalyticsViewProps) {
               {t('reports:analytics.topComposers')}
             </h3>
             <DistributionPie
-              data={analytics.distributionData?.byComposer?.slice(0, 10) || []}
+              data={analytics.distributionData?.byComposer || []}
               type="doughnut"
+              maxItems={5}
             />
           </div>
         </div>

--- a/frontendv2/src/components/practice-reports/visualizations/charts/DistributionPie.tsx
+++ b/frontendv2/src/components/practice-reports/visualizations/charts/DistributionPie.tsx
@@ -16,6 +16,7 @@ interface DistributionPieProps {
   showLegend?: boolean
   type?: 'pie' | 'doughnut' | 'instrument' | 'piece' | 'composer'
   className?: string
+  maxItems?: number
 }
 
 export function DistributionPie({
@@ -25,6 +26,7 @@ export function DistributionPie({
   showLegend = true,
   type = 'pie',
   className,
+  maxItems = 10,
 }: DistributionPieProps) {
   const chartType = type === 'doughnut' || type === 'pie' ? type : 'pie'
   const { t } = useTranslation(['reports'])
@@ -33,17 +35,17 @@ export function DistributionPie({
     // Sort data by value descending
     const sortedData = [...data].sort((a, b) => b.value - a.value)
 
-    // Limit to top 10 items and group the rest as "Other"
+    // Limit to top N items and group the rest as "Other"
     let displayData = sortedData
-    if (sortedData.length > 10) {
-      const top10 = sortedData.slice(0, 10)
+    if (sortedData.length > maxItems) {
+      const topItems = sortedData.slice(0, maxItems)
       const otherValue = sortedData
-        .slice(10)
+        .slice(maxItems)
         .reduce((sum, item) => sum + item.value, 0)
       const total = sortedData.reduce((sum, item) => sum + item.value, 0)
 
       displayData = [
-        ...top10,
+        ...topItems,
         {
           label: t('reports:charts.other'),
           value: otherValue,
@@ -80,7 +82,7 @@ export function DistributionPie({
         },
       ],
     }
-  }, [data, t])
+  }, [data, t, maxItems])
 
   const config: ChartConfig = {
     type: chartType,

--- a/frontendv2/src/hooks/useEnhancedAnalytics.ts
+++ b/frontendv2/src/hooks/useEnhancedAnalytics.ts
@@ -11,6 +11,7 @@ import {
   ComparativeData,
 } from '../types/reporting'
 import { reportsCache } from '../utils/reportsCacheManager'
+import { toTitleCase } from '../utils/textFormatting'
 
 interface UseEnhancedAnalyticsProps {
   entries: LogbookEntry[]
@@ -620,8 +621,8 @@ function calculateDistributionData(entries: LogbookEntry[]): {
 
     // Piece and composer distribution
     entry.pieces.forEach(piece => {
-      const pieceKey = piece.title
-      const composerKey = piece.composer || 'Unknown'
+      const pieceKey = toTitleCase(piece.title)
+      const composerKey = toTitleCase(piece.composer || 'Unknown')
 
       pieceMap.set(pieceKey, (pieceMap.get(pieceKey) || 0) + entry.duration)
       composerMap.set(


### PR DESCRIPTION
## Summary
- Fixed piece/composer name normalization in analytics charts
- Changed Top Pieces and Top Composers charts to show 5 items instead of 10
- Added configurable `maxItems` prop to DistributionPie component

## Problem
As reported in #449:
- Piece names and composer names were not being normalized (capitalization was inconsistent)
- Charts were showing too many items (10), making them less focused

## Solution
1. **Added normalization**: Applied `toTitleCase` function to piece titles and composer names in `useEnhancedAnalytics` hook
2. **Made charts configurable**: Added `maxItems` prop to `DistributionPie` component (defaults to 10 for backward compatibility)
3. **Updated Analytics view**: Set `maxItems={5}` for Top Pieces and Top Composers charts
4. **Aggregation**: Items beyond the limit are grouped as "Others"

## Testing
- ✅ All unit tests pass
- ✅ TypeScript compilation successful
- ✅ ESLint checks pass
- ✅ Pre-commit hooks pass

## Screenshots
The changes ensure:
- Consistent capitalization (e.g., "sonata in c major" → "Sonata In C Major")
- Cleaner visualization with top 5 items + "Others"
- Better focus on most practiced pieces/composers

Fixes #449

🤖 Generated with [Claude Code](https://claude.ai/code)