### PR TITLE
feat: add beta toggle to hide Scorebook feature by default

### DIFF
--- a/frontendv2/src/App.tsx
+++ b/frontendv2/src/App.tsx
@@ -12,6 +12,7 @@ import { useRepertoireStore } from './stores/repertoireStore'
 import { setupPdfWorker } from './utils/pdfWorkerSetup'
 import { AutoLoggingProvider } from './modules/auto-logging'
 import { runLowercaseMigration } from './utils/migrations/lowercaseMigration'
+import { useBetaFeature } from './hooks/useBetaFeatures'
 
 // Set up PDF worker before any components load
 setupPdfWorker()
@@ -49,6 +50,34 @@ function RouteChangeHandler({ children }: { children: React.ReactNode }) {
     // Refresh auth status on route change to ensure UI is in sync
     refreshAuth()
   }, [location.pathname, refreshAuth])
+
+  return <>{children}</>
+}
+
+// Component to handle beta-protected routes
+function BetaProtectedRoute({ children }: { children: React.ReactNode }) {
+  const isScorebookEnabled = useBetaFeature('scorebook')
+
+  if (!isScorebookEnabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-morandi-stone-100">
+        <div className="max-w-md mx-auto text-center p-8">
+          <h2 className="text-2xl font-lexend text-morandi-stone-700 mb-4">
+            Feature Not Available
+          </h2>
+          <p className="text-gray-600 mb-6">
+            The Scorebook feature is currently in beta and not enabled.
+          </p>
+          <p className="text-sm text-gray-500 mb-4">
+            To enable beta features, add{' '}
+            <code className="bg-gray-100 px-2 py-1 rounded">?beta=on</code> to
+            any URL.
+          </p>
+          <Navigate to="/" replace />
+        </div>
+      </div>
+    )
+  }
 
   return <>{children}</>
 }
@@ -141,46 +170,56 @@ function App() {
                   }
                 />
 
-                {/* Scorebook routes (public access) */}
+                {/* Scorebook routes (beta-protected) */}
                 <Route path="/scorebook">
                   <Route
                     index
                     element={
-                      <Suspense fallback={<PageLoader />}>
-                        <ScoreBrowser />
-                      </Suspense>
+                      <BetaProtectedRoute>
+                        <Suspense fallback={<PageLoader />}>
+                          <ScoreBrowser />
+                        </Suspense>
+                      </BetaProtectedRoute>
                     }
                   />
                   <Route
                     path="browse"
                     element={
-                      <Suspense fallback={<PageLoader />}>
-                        <ScoreBrowser />
-                      </Suspense>
+                      <BetaProtectedRoute>
+                        <Suspense fallback={<PageLoader />}>
+                          <ScoreBrowser />
+                        </Suspense>
+                      </BetaProtectedRoute>
                     }
                   />
                   <Route
                     path="collection/user/:id"
                     element={
-                      <Suspense fallback={<PageLoader />}>
-                        <CollectionView />
-                      </Suspense>
+                      <BetaProtectedRoute>
+                        <Suspense fallback={<PageLoader />}>
+                          <CollectionView />
+                        </Suspense>
+                      </BetaProtectedRoute>
                     }
                   />
                   <Route
                     path="collection/:slug"
                     element={
-                      <Suspense fallback={<PageLoader />}>
-                        <CollectionView />
-                      </Suspense>
+                      <BetaProtectedRoute>
+                        <Suspense fallback={<PageLoader />}>
+                          <CollectionView />
+                        </Suspense>
+                      </BetaProtectedRoute>
                     }
                   />
                   <Route
                     path=":scoreId"
                     element={
-                      <Suspense fallback={<PageLoader />}>
-                        <ScorebookPage />
-                      </Suspense>
+                      <BetaProtectedRoute>
+                        <Suspense fallback={<PageLoader />}>
+                          <ScorebookPage />
+                        </Suspense>
+                      </BetaProtectedRoute>
                     }
                   />
                 </Route>

--- a/frontendv2/src/components/layout/AppLayout.tsx
+++ b/frontendv2/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom'
 import Sidebar from './Sidebar'
 import BottomTabs from './BottomTabs'
 import SignInModal from '../auth/SignInModal'
+import { useBetaFeature } from '../../hooks/useBetaFeatures'
 
 interface AppLayoutProps {
   children: React.ReactNode
@@ -30,6 +31,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   })
 
   const location = useLocation()
+  const isScorebookEnabled = useBetaFeature('scorebook')
 
   // Save sidebar state to localStorage when it changes
   useEffect(() => {
@@ -50,8 +52,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({
     ) {
       onNewEntry?.()
     } else if (
-      location.pathname === '/scorebook/browse' ||
-      location.pathname.startsWith('/scorebook')
+      isScorebookEnabled &&
+      (location.pathname === '/scorebook/browse' ||
+        location.pathname.startsWith('/scorebook'))
     ) {
       onImportScore?.()
     } else if (

--- a/frontendv2/src/components/layout/Sidebar.tsx
+++ b/frontendv2/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import { IconInfoSquareRoundedFilled } from '@tabler/icons-react'
 import { useAuthStore } from '../../stores/authStore'
 import Button from '../ui/Button'
 import { SyncIndicator } from '../SyncIndicator'
+import { useBetaFeature } from '../../hooks/useBetaFeatures'
 
 interface SidebarProps {
   className?: string
@@ -43,6 +44,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   const { user, isAuthenticated, logout } = useAuthStore()
   const [showUserDropdown, setShowUserDropdown] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const isScorebookEnabled = useBetaFeature('scorebook')
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -58,7 +60,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  const navItems = [
+  const allNavItems = [
     {
       id: 'logbook',
       label: t('logbook:title'),
@@ -76,6 +78,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       label: t('scorebook:title'),
       path: '/scorebook/browse',
       icon: FileText,
+      beta: true,
     },
     {
       id: 'tools',
@@ -84,6 +87,9 @@ const Sidebar: React.FC<SidebarProps> = ({
       icon: Wrench,
     },
   ]
+
+  // Filter nav items based on beta features
+  const navItems = allNavItems.filter(item => !item.beta || isScorebookEnabled)
 
   const getUserInitials = () => {
     if (!user) return '?'

--- a/frontendv2/src/hooks/useBetaFeatures.ts
+++ b/frontendv2/src/hooks/useBetaFeatures.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+
+interface BetaFeatures {
+  scorebook: boolean
+}
+
+const BETA_STORAGE_KEY = 'mirubato:beta-features'
+
+export function useBetaFeatures(): BetaFeatures {
+  const location = useLocation()
+  const [features, setFeatures] = useState<BetaFeatures>(() => {
+    // Check sessionStorage for existing beta state
+    const stored = sessionStorage.getItem(BETA_STORAGE_KEY)
+    if (stored) {
+      try {
+        return JSON.parse(stored)
+      } catch {
+        // If parse fails, use default
+      }
+    }
+
+    // Default state - all beta features OFF
+    return {
+      scorebook: false,
+    }
+  })
+
+  useEffect(() => {
+    // Check URL params for beta flag
+    const params = new URLSearchParams(location.search)
+    const betaParam = params.get('beta')
+
+    if (betaParam !== null) {
+      // If beta param is present, update state
+      const isEnabled = betaParam === 'on'
+      const newFeatures = {
+        scorebook: isEnabled,
+      }
+
+      setFeatures(newFeatures)
+
+      // Store in sessionStorage so it persists during navigation
+      // but clears when browser/tab is closed
+      if (isEnabled) {
+        sessionStorage.setItem(BETA_STORAGE_KEY, JSON.stringify(newFeatures))
+      } else {
+        sessionStorage.removeItem(BETA_STORAGE_KEY)
+      }
+
+      // Remove the beta param from URL to keep it clean
+      params.delete('beta')
+      const newSearch = params.toString()
+      const newUrl =
+        location.pathname + (newSearch ? `?${newSearch}` : '') + location.hash
+
+      // Replace current URL without the beta param
+      window.history.replaceState({}, '', newUrl)
+    }
+  }, [location])
+
+  return features
+}
+
+// Helper hook to check if a specific feature is enabled
+export function useBetaFeature(feature: keyof BetaFeatures): boolean {
+  const features = useBetaFeatures()
+  return features[feature]
+}


### PR DESCRIPTION
## Summary
- Implements a URL parameter-based beta switch to toggle the Scorebook feature
- Scorebook is hidden by default and can be enabled with `?beta=on`
- Beta state persists in sessionStorage during navigation but clears on browser close

## Changes
- Added `useBetaFeatures` hook to manage beta state via URL parameters
- Updated Sidebar component to conditionally show Scorebook navigation
- Added `BetaProtectedRoute` component to protect Scorebook routes
- Updated AppLayout to conditionally handle Scorebook import actions
- Shows friendly "Feature Not Available" message when accessing Scorebook without beta enabled

## How to Test
1. **Default state (Beta OFF)**: Navigate to the app - Scorebook should NOT be visible in sidebar
2. **Enable beta**: Add `?beta=on` to any URL - Scorebook appears in sidebar
3. **Persistence**: Navigate around - Scorebook remains visible during session
4. **Direct access**: Try accessing `/scorebook/browse` without beta - shows friendly message
5. **Disable beta**: Add `?beta=off` to URL - Scorebook disappears

## Implementation Details
- No UI toggle as requested - purely URL parameter based
- Clean URLs maintained (beta param is removed after being read)
- Non-intrusive implementation that can be easily removed when feature is stable

Resolves #456

🤖 Generated with [Claude Code](https://claude.ai/code)