### PR TITLE
fix: correct button text in Add to Repertoire modal

### DIFF
--- a/frontendv2/src/components/repertoire/AddToRepertoirePrompt.tsx
+++ b/frontendv2/src/components/repertoire/AddToRepertoirePrompt.tsx
@@ -79,7 +79,7 @@ export function AddToRepertoirePrompt({
               onClick={handleAdd}
               disabled={isAdding}
             >
-              {isAdding ? t('common:adding') : t('repertoire:addToEntries')}
+              {isAdding ? t('common:adding') : t('repertoire:addToRepertoire')}
             </Button>
             <Button variant="ghost" size="sm" onClick={onClose}>
               {t('common:notNow')}


### PR DESCRIPTION
## Summary
- Fixes button text from "Add to Entries" to "Add to Pieces" in the Add to Repertoire modal
- Resolves issue #461

## Changes
- Updated translation key in `AddToRepertoirePrompt.tsx` from `addToEntries` to `addToRepertoire`
- This uses the existing translation that already says "Add to Pieces" in English and appropriate translations in other languages

## Test Plan
- [x] Verify button shows "Add to Pieces" when adding a new piece from the logbook
- [x] Check translations work correctly in other languages
- [x] All tests pass

Fixes #461

🤖 Generated with [Claude Code](https://claude.ai/code)