### PR TITLE
fix: add year to date displays and fix button nesting warning

### DIFF
--- a/frontendv2/src/components/LogbookEntryList.tsx
+++ b/frontendv2/src/components/LogbookEntryList.tsx
@@ -401,6 +401,7 @@ export default function LogbookEntryList({
           const formattedDate = entryDate.toLocaleDateString(i18n.language, {
             month: 'short',
             day: '2-digit',
+            year: 'numeric',
           })
 
           return (

--- a/frontendv2/src/components/practice-reports/components/RecentEntries.tsx
+++ b/frontendv2/src/components/practice-reports/components/RecentEntries.tsx
@@ -59,6 +59,7 @@ export function RecentEntries({
           const formattedDate = date.toLocaleDateString(i18n.language, {
             month: 'short',
             day: '2-digit',
+            year: 'numeric',
           })
 
           return (

--- a/frontendv2/src/components/repertoire/PieceDetailView.tsx
+++ b/frontendv2/src/components/repertoire/PieceDetailView.tsx
@@ -258,7 +258,7 @@ export const PieceDetailView: React.FC<PieceDetailViewProps> = ({
     const date = new Date(timestamp)
     if (isToday(date)) return t('common:time.today')
     if (isYesterday(date)) return t('common:time.yesterday')
-    return format(date, 'MMMM d')
+    return format(date, 'MMMM d, yyyy')
   }
 
   const formatSessionTime = (timestamp: string | number) => {

--- a/frontendv2/src/components/repertoire/RepertoireCard.tsx
+++ b/frontendv2/src/components/repertoire/RepertoireCard.tsx
@@ -323,7 +323,14 @@ export function RepertoireCard({ item, onEditSession }: RepertoireCardProps) {
                       <div className="flex items-center justify-between mb-2">
                         <div className="flex items-center gap-3">
                           <span className="text-sm font-medium text-stone-900">
-                            {new Date(session.timestamp).toLocaleDateString()}
+                            {new Date(session.timestamp).toLocaleDateString(
+                              undefined,
+                              {
+                                year: 'numeric',
+                                month: 'short',
+                                day: 'numeric',
+                              }
+                            )}
                           </span>
                           <span className="text-sm text-stone-600">
                             {new Date(session.timestamp).toLocaleTimeString(

--- a/frontendv2/src/components/timer/TimerWidget.tsx
+++ b/frontendv2/src/components/timer/TimerWidget.tsx
@@ -15,12 +15,12 @@ export function TimerWidget({ isCollapsed }: TimerWidgetProps) {
 
   return (
     <div className={`${isCollapsed ? 'px-2' : 'px-4'}`}>
-      <button
+      <div
         onClick={openModal}
         className={`
           w-full flex items-center ${isCollapsed ? 'justify-center' : 'gap-2'} 
           ${isCollapsed ? 'px-2 py-2' : 'px-3 py-2'} 
-          rounded-lg transition-all
+          rounded-lg transition-all cursor-pointer
           ${isRunning ? 'bg-green-100 hover:bg-green-200' : 'bg-gray-100 hover:bg-gray-200'}
           group relative
         `}
@@ -70,7 +70,7 @@ export function TimerWidget({ isCollapsed }: TimerWidgetProps) {
             </button>
           </>
         )}
-      </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Fixes #465 - Added year to all date displays throughout the application
- Fixed invalid DOM nesting warning in TimerWidget component

## Changes Made

### Date Display Updates
- **LogbookEntryList**: Added year to date separators
- **RecentEntries**: Added year to date separators in Logbook Overview page  
- **PieceDetailView**: Added year to practice session dates
- **RepertoireCard**: Added year to practice history dates

### DOM Nesting Fix
- **TimerWidget**: Changed outer wrapper from `<button>` to `<div>` to fix invalid nesting of button elements

## Testing
- ✅ All unit tests passing
- ✅ Build completed successfully
- ✅ No linting errors
- ✅ Pre-commit hooks passed

## Screenshots
All date displays now consistently show full dates with year (e.g., "Aug 10, 2024" instead of "Aug 10") for better historical context when viewing practice data across different years.

🤖 Generated with [Claude Code](https://claude.ai/code)