### PR TITLE
feat: Add daily practice totals to logbook date separators

### DIFF
--- a/frontendv2/src/components/practice-reports/components/RecentEntries.tsx
+++ b/frontendv2/src/components/practice-reports/components/RecentEntries.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { LogbookEntry } from '../../../api/logbook'
 import { EntryCard } from './EntryCard'
 import { Card } from '../../ui/Card'
+import { formatDuration } from '../../../utils/dateUtils'
 
 interface RecentEntriesProps {
   entries: LogbookEntry[]
@@ -38,8 +39,17 @@ export function RecentEntries({
     )
   }
 
-  // Track which dates have been shown
+  // Track which dates have been shown and calculate daily totals
   const shownDates = new Set<string>()
+  const dailyTotals = new Map<string, number>()
+
+  // Calculate daily totals first
+  recentEntries.forEach(entry => {
+    const date = new Date(entry.timestamp)
+    const entryDate = date.toDateString()
+    const currentTotal = dailyTotals.get(entryDate) || 0
+    dailyTotals.set(entryDate, currentTotal + entry.duration)
+  })
 
   return (
     <div className={className}>
@@ -62,6 +72,9 @@ export function RecentEntries({
             year: 'numeric',
           })
 
+          // Get the daily total for this date
+          const dayTotal = dailyTotals.get(entryDate) || 0
+
           return (
             <div key={entry.id}>
               {/* Date Separator */}
@@ -69,6 +82,9 @@ export function RecentEntries({
                 <div className="flex items-center gap-3 mb-3">
                   <span className="text-sm font-bold text-gray-600 whitespace-nowrap">
                     {formattedDate}
+                  </span>
+                  <span className="text-sm font-bold text-gray-600">
+                    · {formatDuration(dayTotal)}
                   </span>
                   <div className="flex-1 h-px bg-gray-200"></div>
                 </div>


### PR DESCRIPTION
## Summary
- Adds total practice time calculation and display for each day in the Logbook > Overview > Recent Entries section
- Shows daily totals in a clean, minimal format next to the date separator
- Uses consistent font styling with the date for visual harmony

## Changes
- Calculate total practice time for all entries on each day
- Display the total next to the date in format: "Dec 12, 2025 · 1h 30m"
- Reuses existing `formatDuration` utility and translation keys
- No new dependencies or API changes required

## Screenshots
Daily totals now appear inline with date separators, providing at-a-glance insights into daily practice patterns.

## Test Plan
- [x] TypeScript compilation passes
- [x] All unit tests pass
- [x] Linting passes
- [x] Visual verification of daily totals display
- [x] Correct calculation of multiple entries per day
- [x] Proper formatting for various duration ranges (minutes only, hours only, hours + minutes)

Fixes #473

🤖 Generated with [Claude Code](https://claude.ai/code)