### PR TITLE
fix: add composer and piece title autocomplete to edit modals

### DIFF
--- a/frontendv2/src/components/practice-reports/EditPieceModal.tsx
+++ b/frontendv2/src/components/practice-reports/EditPieceModal.tsx
@@ -4,6 +4,9 @@ import { AlertCircle } from 'lucide-react'
 import { Modal } from '../ui/Modal'
 import Button from '../ui/Button'
 import { Input } from '../ui/Input'
+import Autocomplete from '../ui/Autocomplete'
+import { useAutocomplete } from '../../hooks/useAutocomplete'
+import { formatComposerName } from '../../utils/textFormatting'
 import { useLogbookStore } from '../../stores/logbookStore'
 
 interface EditPieceModalProps {
@@ -32,6 +35,12 @@ export const EditPieceModal: React.FC<EditPieceModalProps> = ({
   const [composer, setComposer] = useState(piece.composer || '')
   const [error, setError] = useState('')
   const [affectedCount, setAffectedCount] = useState(0)
+
+  // Autocomplete for composer
+  const composerAutocomplete = useAutocomplete({
+    type: 'composer',
+    minLength: 0, // Show suggestions immediately
+  })
 
   // Calculate how many entries will be affected
   useEffect(() => {
@@ -136,14 +145,28 @@ export const EditPieceModal: React.FC<EditPieceModalProps> = ({
           <label className="block text-sm font-medium text-gray-700 mb-1">
             {t('reports:pieceEdit.composer')}
           </label>
-          <Input
-            type="text"
+          <Autocomplete
             value={composer}
-            onChange={e => {
-              setComposer(e.target.value)
+            onChange={value => {
+              setComposer(value)
+              composerAutocomplete.setQuery(value)
               setError('')
             }}
+            onBlur={() => {
+              // Auto-capitalize composer name on blur
+              if (composer && composer.trim()) {
+                const formatted = formatComposerName(composer.trim())
+                if (formatted !== composer) {
+                  setComposer(formatted)
+                }
+              }
+            }}
+            onSelect={() => {
+              // Selection is already handled by onChange in Autocomplete component
+            }}
+            options={composerAutocomplete.suggestions}
             placeholder={t('reports:pieceEdit.composerPlaceholder')}
+            isLoading={composerAutocomplete.isLoading}
             className="w-full"
           />
         </div>

--- a/frontendv2/src/components/repertoire/AddToRepertoireModal.tsx
+++ b/frontendv2/src/components/repertoire/AddToRepertoireModal.tsx
@@ -49,6 +49,13 @@ export function AddToRepertoireModal({
   } = useScoreStore()
   const { entries } = useLogbookStore()
 
+  // Autocomplete for piece title
+  const pieceAutocomplete = useAutocomplete({
+    type: 'piece',
+    composer: customComposer || undefined, // Filter by composer if already selected
+    minLength: 0, // Show suggestions immediately
+  })
+
   // Autocomplete for composer
   const composerAutocomplete = useAutocomplete({
     type: 'composer',
@@ -313,7 +320,8 @@ export function AddToRepertoireModal({
                 {showCustomEntry && (
                   <Card className="p-3 sm:p-4 space-y-3 bg-sage-50 border-sage-200">
                     {/* Offline indicator - only show when offline */}
-                    {composerAutocomplete.isOffline && (
+                    {(pieceAutocomplete.isOffline ||
+                      composerAutocomplete.isOffline) && (
                       <div className="text-xs text-amber-600 flex items-center gap-1 mb-2">
                         <svg
                           className="w-3 h-3"
@@ -340,12 +348,26 @@ export function AddToRepertoireModal({
                       <label className="block text-sm font-medium text-stone-700 mb-1">
                         {t('repertoire:pieceTitle')} *
                       </label>
-                      <Input
-                        type="text"
+                      <Autocomplete
                         value={customTitle}
-                        onChange={e => setCustomTitle(e.target.value)}
+                        onChange={value => {
+                          setCustomTitle(value)
+                          pieceAutocomplete.setQuery(value)
+                        }}
+                        onSelect={option => {
+                          // If the selected piece has a composer, auto-fill it
+                          if (option.metadata?.composer) {
+                            setCustomComposer(option.metadata.composer)
+                          }
+                        }}
+                        options={pieceAutocomplete.suggestions}
                         placeholder={t('repertoire:pieceTitlePlaceholder')}
+                        isLoading={pieceAutocomplete.isLoading}
                         className="w-full"
+                        emptyMessage={t(
+                          'repertoire:noPiecesFound',
+                          'No pieces found'
+                        )}
                       />
                     </div>
                     <div>


### PR DESCRIPTION
## Summary
- Adds composer autocomplete to the Edit Piece modal in Reports section
- Adds piece title autocomplete to the Custom Entry in Add to Repertoire modal  
- Ensures consistent autocomplete experience across all input modals

## Changes
1. **Edit Piece Modal** (`EditPieceModal.tsx`)
   - Replaced plain Input with Autocomplete component for composer field
   - Added auto-formatting on blur using `formatComposerName`
   - Shows suggestions immediately on focus (minLength: 0)

2. **Add to Repertoire Modal** (`AddToRepertoireModal.tsx`)
   - Replaced plain Input with Autocomplete component for piece title in Custom Entry
   - Auto-fills composer field when selecting a piece with known composer
   - Updated offline indicator to show when either autocomplete is offline

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint passes with no errors
- [x] All unit tests pass
- [ ] Manual testing: Edit Piece modal shows composer suggestions
- [ ] Manual testing: Custom Entry in Add to Repertoire shows piece title suggestions
- [ ] Manual testing: Selecting a piece auto-fills the composer field

## Related Issue
Fixes #463

🤖 Generated with [Claude Code](https://claude.ai/code)