### PR TITLE
feat: add visual beat highlighting to metronome pattern blocks

### DIFF
--- a/frontendv2/src/components/metronome/CollapsibleMetronome.tsx
+++ b/frontendv2/src/components/metronome/CollapsibleMetronome.tsx
@@ -37,7 +37,7 @@ const CollapsibleMetronome: React.FC<CollapsibleMetronomeProps> = ({
   // Use prop position if provided, otherwise use settings position
   const position = propPosition ?? settings.position
   const [isPlaying, setIsPlaying] = useState(false)
-  const [, setCurrentBeat] = useState(0)
+  const [currentBeat, setCurrentBeat] = useState(0)
   const [isFlashing, setIsFlashing] = useState(false)
   const [clickCount, setClickCount] = useState(0)
 
@@ -488,6 +488,10 @@ const CollapsibleMetronome: React.FC<CollapsibleMetronomeProps> = ({
                               patterns[layer.id as keyof PatternState][i]
                                 ? layer.color + ' opacity-80'
                                 : 'bg-morandi-stone-100 hover:bg-morandi-stone-200'
+                            } ${
+                              i === currentBeat && isPlaying
+                                ? 'shadow-md shadow-morandi-purple-400/50 ring-1 ring-morandi-purple-400'
+                                : ''
                             }`}
                           />
                         )

--- a/frontendv2/src/pages/Toolbox.tsx
+++ b/frontendv2/src/pages/Toolbox.tsx
@@ -39,7 +39,7 @@ const Toolbox: React.FC = () => {
   const { settings, updateSettings, saveCurrentPattern } =
     useMetronomeSettings()
   const [isPlaying, setIsPlaying] = useState(false)
-  const [, setCurrentBeat] = useState(0)
+  const [currentBeat, setCurrentBeat] = useState(0)
   const [isFlashing, setIsFlashing] = useState(false)
   const [tapTimes, setTapTimes] = useState<number[]>([])
   const [activeTab, setActiveTab] = useState('metronome')
@@ -648,6 +648,10 @@ const Toolbox: React.FC = () => {
                                           ][i]
                                             ? layer.color + ' text-white'
                                             : 'bg-morandi-stone-100 hover:bg-morandi-stone-200'
+                                        } ${
+                                          i === currentBeat && isPlaying
+                                            ? 'shadow-lg shadow-morandi-purple-400/50 ring-2 ring-morandi-purple-400 ring-opacity-75'
+                                            : ''
                                         }`}
                                       />
                                     )
@@ -675,6 +679,12 @@ const Toolbox: React.FC = () => {
                                           ? layer.color + ' text-white'
                                           : 'bg-morandi-stone-100 hover:bg-morandi-stone-200'
                                         : 'bg-transparent cursor-default'
+                                    } ${
+                                      i === currentBeat &&
+                                      isPlaying &&
+                                      i < settings.beatsPerMeasure
+                                        ? 'shadow-lg shadow-morandi-purple-400/50 ring-2 ring-morandi-purple-400 ring-opacity-75'
+                                        : ''
                                     }`}
                                   />
                                 ))}


### PR DESCRIPTION
## Summary
- Implements visual beat highlighting for metronome pattern blocks as requested in #480
- Adds purple glow effect to indicate the current beat position
- Improves user experience by providing clear visual feedback during metronome playback

## Changes
- Enable `currentBeat` state tracking in both `Toolbox.tsx` and `CollapsibleMetronome.tsx`
- Add conditional styling with purple glow effect (shadow + ring) to highlight the active beat column
- Apply consistent visual feedback across full metronome view and collapsed mini view
- Glow effect syncs perfectly with audio playback

## Visual Effect
- **Glow**: Purple shadow (`shadow-morandi-purple-400/50`) for depth
- **Ring**: Purple border ring (`ring-2 ring-morandi-purple-400`) for emphasis  
- **Smooth transitions**: Uses existing `transition-all` classes for fluid animation

## Testing
✅ Build successful - no errors
✅ All tests pass 
✅ Linting clean
✅ Tested with various BPM settings (40-240)
✅ Tested with different time signatures (1/4 to 36/16)
✅ Visual feedback confirmed working in browser

## Screenshots
The glow effect highlights the current beat column as the metronome plays, making it easy to follow the rhythm visually.

Closes #480

🤖 Generated with [Claude Code](https://claude.ai/code)