### PR TITLE
fix: remove colored status bars from repertoire list items

### DIFF
--- a/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
+++ b/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
@@ -67,17 +67,6 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
 
   const needsAttention = daysSinceLastPractice && daysSinceLastPractice >= 5
 
-  // Determine status indicator color
-  const isActive = lastPracticeDate ? isToday(lastPracticeDate) : false
-  const indicatorClass =
-    item.status === 'polished'
-      ? 'bg-morandi-navy-500' // Dark morandi blue for polished pieces
-      : isActive
-        ? 'bg-green-500'
-        : needsAttention
-          ? 'bg-orange-500'
-          : 'bg-gray-300'
-
   // Format last practice time
   const lastPracticeText = lastPracticeDate
     ? isToday(lastPracticeDate)
@@ -98,10 +87,7 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
 
   return (
     <div className="bg-white rounded-lg border border-stone-200 p-4 hover:shadow-sm transition-shadow">
-      <div className="flex items-start gap-4">
-        {/* Status Indicator */}
-        <div className={`w-1 h-12 rounded-full ${indicatorClass}`} />
-
+      <div className="flex items-start">
         {/* Main Content */}
         <div className="flex-1 min-w-0">
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- Removed the colored vertical indicator bars from the left side of repertoire items in the list view
- Cleaned up unused color logic variables that determined bar colors based on status

## Changes
- Removed the status indicator div that created the colored vertical bar
- Adjusted layout spacing after removing the bar  
- Removed unused variables related to indicator color logic (green for practiced today, orange for needs attention, etc.)

## Testing
- ✅ All tests passing
- ✅ Linter passes with no errors
- ✅ Build completes successfully
- ✅ Visual inspection confirms bars are removed

## Related Issue
Fixes #439

🤖 Generated with [Claude Code](https://claude.ai/code)