### PR TITLE
fix: improve mobile layout by removing Sessions block from summary stats

### DIFF
--- a/frontendv2/src/components/practice-reports/SummaryStats.tsx
+++ b/frontendv2/src/components/practice-reports/SummaryStats.tsx
@@ -24,11 +24,6 @@ export function SummaryStats({
     )
   }
 
-  const getSessionCount = () => {
-    // Use filtered entries count directly
-    return filteredAndSortedEntries.length
-  }
-
   return (
     <div className="space-y-2" data-testid="summary-stats">
       {/* Summary Stats Grid - Now 4 stats for better mobile layout */}


### PR DESCRIPTION
## Summary
- Removed the 'Sessions' status block from the logbook overview summary stats
- Changed grid layout from 5 columns to 4 columns for better responsive design
- Creates a balanced 2x2 grid on mobile instead of an uneven 2-2-1 layout

## Problem
The logbook overview displayed 5 status summary blocks which created an unbalanced layout on mobile devices. With `grid-cols-2` on mobile, the 5 blocks would arrange as 2-2-1, making the interface look unpolished.

## Solution
By removing the 'Sessions' block and keeping the 4 most important metrics:
- Today's Practice
- This Week
- Current Streak  
- Total Practice

The interface now displays a clean 2x2 grid on mobile and a balanced 4-column layout on desktop.

## Testing
- [x] Tested on mobile viewport
- [x] Tested on desktop viewport
- [x] All unit tests pass
- [x] Linting passes

Fixes #437

🤖 Generated with [Claude Code](https://claude.ai/code)