### PR TITLE
fix: reduce header padding to improve UI density

### DIFF
--- a/frontendv2/src/components/ManualEntryForm.tsx
+++ b/frontendv2/src/components/ManualEntryForm.tsx
@@ -582,7 +582,7 @@ export default function ManualEntryForm({
       {/* Duplicate Detection Modal */}
       {duplicateMatches && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg p-4 sm:p-6 w-full max-w-md sm:max-w-lg max-h-[90vh] overflow-y-auto">
+          <div className="bg-white rounded-lg p-3 sm:p-4 w-full max-w-md sm:max-w-lg max-h-[90vh] overflow-y-auto">
             <p className="text-stone-700 mb-4 text-sm sm:text-base">
               {t('logbook:entry.duplicateDetection.similarTo', {
                 title: duplicateMatches.piece.title,

--- a/frontendv2/src/components/practice-reports/EnhancedReports.tsx
+++ b/frontendv2/src/components/practice-reports/EnhancedReports.tsx
@@ -191,7 +191,7 @@ export default function EnhancedReports({
       {reportView === 'newEntry' ? (
         <Suspense
           fallback={
-            <div className="p-4 sm:p-6">
+            <div className="p-3 sm:p-4">
               <LoadingSkeleton className="h-96" />
             </div>
           }
@@ -213,7 +213,7 @@ export default function EnhancedReports({
       ) : (
         <Suspense
           fallback={
-            <div className="p-4 sm:p-6">
+            <div className="p-3 sm:p-4">
               <LoadingSkeleton className="h-96" />
             </div>
           }

--- a/frontendv2/src/components/practice-reports/ReportsTabs.tsx
+++ b/frontendv2/src/components/practice-reports/ReportsTabs.tsx
@@ -58,7 +58,7 @@ export function ReportsTabs({
       tabs={tabs}
       activeTab={reportView}
       onTabChange={handleTabChange}
-      className="mb-6"
+      className="mb-3 sm:mb-4"
     />
   )
 }

--- a/frontendv2/src/components/practice-reports/views/DataView.tsx
+++ b/frontendv2/src/components/practice-reports/views/DataView.tsx
@@ -65,7 +65,7 @@ export default function DataView({ analytics }: DataViewProps) {
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-morandi-stone-200 w-full">
-      <div className="p-2 sm:p-4 lg:p-6">
+      <div className="p-2 sm:p-3 lg:p-4">
         {/* Segmented Control for view selection */}
         <div className="mb-4 sm:mb-6 flex justify-center sm:justify-start">
           <SegmentedControl

--- a/frontendv2/src/components/practice-reports/views/OverviewView.tsx
+++ b/frontendv2/src/components/practice-reports/views/OverviewView.tsx
@@ -48,7 +48,7 @@ export default function OverviewView({ analytics }: OverviewViewProps) {
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-morandi-stone-200 w-full">
-      <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
+      <div className="p-3 sm:p-4 space-y-3 sm:space-y-4">
         {/* Summary Statistics - Moved to top */}
         <div className="w-full">
           <SummaryStats

--- a/frontendv2/src/components/repertoire/RepertoireView.tsx
+++ b/frontendv2/src/components/repertoire/RepertoireView.tsx
@@ -472,7 +472,7 @@ export default function RepertoireView({ analytics }: RepertoireViewProps) {
     <div className="space-y-6">
       {/* Repertoire Statistics */}
       <div className="bg-white rounded-lg shadow-sm border border-morandi-stone-200 w-full">
-        <div className="p-4 sm:p-6">
+        <div className="p-3 sm:p-4">
           <RepertoireStats repertoireItems={filteredItems} />
         </div>
       </div>

--- a/frontendv2/src/pages/About.tsx
+++ b/frontendv2/src/pages/About.tsx
@@ -30,7 +30,7 @@ export default function About() {
 
   return (
     <AppLayout>
-      <div className="p-4 sm:p-8">
+      <div className="p-3 sm:px-6 sm:py-4">
         {/* Tabs */}
         <Tabs
           tabs={[
@@ -67,7 +67,7 @@ export default function About() {
           ]}
           activeTab={activeTab}
           onTabChange={setActiveTab}
-          className="mb-6"
+          className="mb-3 sm:mb-4"
         />
 
         {/* Tab Content */}

--- a/frontendv2/src/pages/Logbook.tsx
+++ b/frontendv2/src/pages/Logbook.tsx
@@ -36,7 +36,7 @@ export default function LogbookPage() {
       onTimerClick={openModal}
     >
       <PullToRefresh className="h-full">
-        <div className="p-4 sm:p-8">
+        <div className="p-3 sm:px-6 sm:py-4">
           {/* Error Display */}
           {error && (
             <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6 animate-slide-up">

--- a/frontendv2/src/pages/ScoreBrowser.tsx
+++ b/frontendv2/src/pages/ScoreBrowser.tsx
@@ -509,7 +509,7 @@ export default function ScoreBrowserPage() {
       onTimerClick={() => setShowTimer(true)}
       onImportScore={() => setShowImportModal(true)}
     >
-      <div className="p-8">
+      <div className="p-3 sm:px-6 sm:py-4">
         {/* Navigation Tabs - Outside any white box to match Toolbox/Logbook */}
         <Tabs
           tabs={[
@@ -556,7 +556,7 @@ export default function ScoreBrowserPage() {
 
           {/* Filters - only show for scores tab */}
           {tabView === 'scores' && (
-            <div className="p-4 md:p-6 border-b border-morandi-stone-200">
+            <div className="p-3 md:p-4 border-b border-morandi-stone-200">
               <div className="flex gap-4">
                 <select
                   value={selectedInstrument}
@@ -595,7 +595,7 @@ export default function ScoreBrowserPage() {
           )}
 
           {/* Content */}
-          <div className="p-4 md:p-6">
+          <div className="p-3 md:p-4">
             {isLoading ? (
               <div className="text-center py-12">
                 <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-morandi-sage-500 mx-auto mb-4"></div>

--- a/frontendv2/src/pages/Scorebook.tsx
+++ b/frontendv2/src/pages/Scorebook.tsx
@@ -148,7 +148,7 @@ export default function ScorebookPage() {
 
         {/* Error State */}
         {error && (
-          <div className="flex-1 flex items-center justify-center p-4 sm:p-8">
+          <div className="flex-1 flex items-center justify-center p-3 sm:px-6 sm:py-4">
             <div className="bg-red-50 border border-red-200 rounded-lg p-4 sm:p-6 max-w-md">
               <h3 className="text-red-800 font-medium mb-2">
                 {t('scorebook:error', 'Error loading score')}

--- a/frontendv2/src/pages/Toolbox.tsx
+++ b/frontendv2/src/pages/Toolbox.tsx
@@ -390,7 +390,7 @@ const Toolbox: React.FC = () => {
       onToolboxAdd={handleToolboxAdd}
     >
       {/* Main Content */}
-      <div className="p-4 sm:p-8">
+      <div className="p-3 sm:px-6 sm:py-4">
         {/* Tabs */}
         <Tabs
           tabs={[
@@ -425,7 +425,7 @@ const Toolbox: React.FC = () => {
           <div className="flex flex-col lg:flex-row gap-6">
             {/* Control Panel */}
             <div className="lg:w-1/3">
-              <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6 space-y-4 sm:space-y-6">
+              <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 space-y-3 sm:space-y-4">
                 {/* Play/Pause and BPM */}
                 <div className="text-center">
                   <button
@@ -557,7 +557,7 @@ const Toolbox: React.FC = () => {
 
             {/* Beat Pattern Grid */}
             <div className="lg:w-2/3">
-              <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
+              <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4">
                 <div className="w-full">
                   <div
                     className={`${


### PR DESCRIPTION
## Summary
- Reduces excessive vertical padding throughout the application for a more compact, professional UI
- Addresses issue #438 about scattered UI layout with too much top spacing
- Improves content visibility above the fold

## Changes Made

### Padding Reductions
- **Main pages**: Reduced from `p-4 sm:p-8` to `p-3 sm:px-6 sm:py-4` (~50% reduction)
- **Component containers**: Reduced from `p-4 sm:p-6` to `p-3 sm:p-4`
- **Tab navigation**: Reduced margin from `mb-6` to `mb-3 sm:mb-4`

### Files Modified (11 files)
**Pages:**
- `Logbook.tsx`
- `Toolbox.tsx`
- `Scorebook.tsx`
- `ScoreBrowser.tsx`
- `About.tsx`

**Components:**
- `OverviewView.tsx`
- `DataView.tsx`
- `RepertoireView.tsx`
- `ManualEntryForm.tsx`
- `EnhancedReports.tsx`
- `ReportsTabs.tsx`

## Screenshots
Before: More scattered layout with excessive top padding
After: Compact, professional layout with better content density

## Test Plan
- [x] Verified all pages display correctly with reduced padding
- [x] Tested responsive design on mobile and desktop viewports
- [x] Confirmed no visual regressions in component layouts
- [x] All tests passing
- [x] Linting checks passed

Fixes #438

🤖 Generated with [Claude Code](https://claude.ai/code)