### PR TITLE
fix: remove incomplete practice button from scorebook

### DIFF
--- a/frontendv2/src/components/score/CollectionsManager.tsx
+++ b/frontendv2/src/components/score/CollectionsManager.tsx
@@ -124,7 +124,7 @@ export default function CollectionsManager({
   return (
     <div className={cn('flex flex-col h-full', className)}>
       {/* Header */}
-      <div className="flex items-center justify-between p-4 sm:p-6 border-b border-morandi-stone-200">
+      <div className="flex items-center justify-between p-3 sm:p-4 border-b border-morandi-stone-200">
         <h3 className="text-lg font-medium text-morandi-stone-800">
           {scoreId
             ? t('scorebook:manageCollections', 'Manage Collections')
@@ -171,7 +171,7 @@ export default function CollectionsManager({
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+      <div className="flex-1 overflow-y-auto p-3 sm:p-4">
         {error && (
           <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
             {error}
@@ -351,7 +351,7 @@ export default function CollectionsManager({
 
       {/* Footer with save button (only when managing score collections) */}
       {scoreId && (
-        <div className="p-4 sm:p-6 border-t border-morandi-stone-200">
+        <div className="p-3 sm:p-4 border-t border-morandi-stone-200">
           <div className="flex justify-end gap-3">
             <Button variant="ghost" onClick={onClose}>
               {t('common:cancel', 'Cancel')}

--- a/frontendv2/src/components/score/ScoreControls.tsx
+++ b/frontendv2/src/components/score/ScoreControls.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useScoreStore } from '../../stores/scoreStore'
-import { useAuthStore } from '../../stores/authStore'
 import { cn } from '../../utils/cn'
 import {
   getMetronome,
@@ -16,21 +15,12 @@ import {
   Scroll,
   MoreVertical,
 } from 'lucide-react'
-import {
-  usePracticeTracking,
-  PracticeSummaryModal,
-} from '../../modules/auto-logging'
 
 export default function ScoreControls() {
   const { t } = useTranslation(['scorebook', 'common'])
-  const { isAuthenticated } = useAuthStore()
   const {
-    isRecording,
     metronomeSettings,
     autoScrollEnabled,
-    practiceSession,
-    startPractice: originalStartPractice,
-    stopPractice: originalStopPractice,
     setTempo,
     toggleMetronome,
     setMetronomeVolume,
@@ -39,40 +29,14 @@ export default function ScoreControls() {
     currentPage,
     totalPages,
     setCurrentPage,
-    currentScore,
   } = useScoreStore()
 
-  const [elapsedTime, setElapsedTime] = useState(0)
   const [isMobile, setIsMobile] = useState(false)
   const [visualPulse, setVisualPulse] = useState(false)
   const [showAdvancedMetronome, setShowAdvancedMetronome] = useState(false)
   const [clickCount, setClickCount] = useState(0)
   const metronome = getMetronome()
   const pulseTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-
-  // Practice tracking with auto-logging
-  const {
-    isTracking,
-    formattedTime,
-    showSummary,
-    pendingSession,
-    start: startTracking,
-    stop: stopTracking,
-    update: updateTracking,
-    confirmSave,
-    dismissSummary,
-  } = usePracticeTracking({
-    type: 'score',
-    metadata: currentScore
-      ? {
-          scoreId: currentScore.id,
-          scoreTitle: currentScore.title,
-          scoreComposer: currentScore.composer,
-          instrument: 'piano', // Could be made configurable
-          pagesViewed: [currentPage],
-        }
-      : {},
-  })
 
   // Visual callback for metronome beats
   const visualCallback: VisualCallback = {
@@ -149,39 +113,6 @@ export default function ScoreControls() {
     return () => window.removeEventListener('resize', checkMobile)
   }, [])
 
-  // Update elapsed time when recording
-  useEffect(() => {
-    if (!isRecording || !practiceSession) return
-
-    const interval = setInterval(() => {
-      const elapsed = Math.floor(
-        (Date.now() - practiceSession.startTime.getTime()) / 1000
-      )
-      setElapsedTime(elapsed)
-    }, 1000)
-
-    return () => clearInterval(interval)
-  }, [isRecording, practiceSession])
-
-  const formatTime = (seconds: number): string => {
-    const mins = Math.floor(seconds / 60)
-    const secs = seconds % 60
-    return `${mins}:${secs.toString().padStart(2, '0')}`
-  }
-
-  // Update tracking when page changes
-  useEffect(() => {
-    if (isTracking && currentPage) {
-      updateTracking({
-        pagesViewed: [
-          ...(pendingSession?.metadata.pagesViewed || []),
-          currentPage,
-        ],
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPage, isTracking, updateTracking])
-
   // Page navigation handlers
   const changePage = useCallback(
     (offset: number) => {
@@ -219,55 +150,11 @@ export default function ScoreControls() {
     setShowAdvancedMetronome(false)
   }
 
-  // Wrapper functions for practice tracking with auto-logging
-  const startPractice = useCallback(() => {
-    originalStartPractice()
-    if (!isTracking) {
-      startTracking()
-    }
-  }, [originalStartPractice, isTracking, startTracking])
-
-  const stopPractice = useCallback(() => {
-    originalStopPractice()
-    if (isTracking) {
-      stopTracking()
-    }
-  }, [originalStopPractice, isTracking, stopTracking])
-
   // Mobile: Right side vertical layout with semi-transparency
   if (isMobile) {
     return (
       <>
         <div className="fixed right-4 bottom-20 flex flex-col items-center gap-2 bg-white/70 backdrop-blur-sm rounded-2xl shadow-lg border border-morandi-stone-200/50 p-3 z-40">
-          {/* Practice Tracking Toggle - Compact */}
-          {isAuthenticated && (
-            <Button
-              onClick={() => (isRecording ? stopPractice() : startPractice())}
-              variant={isRecording ? 'danger' : 'secondary'}
-              size="sm"
-              className="flex flex-col items-center gap-1"
-            >
-              <div
-                className={cn(
-                  'w-3 h-3 rounded-full',
-                  isRecording ? 'bg-white animate-pulse' : 'bg-red-500'
-                )}
-              />
-              <span className="text-xs font-medium">
-                {isRecording ? (
-                  <>
-                    {t('scorebook:recording', 'Rec')}
-                    <div className="text-xs">
-                      {isTracking ? formattedTime : formatTime(elapsedTime)}
-                    </div>
-                  </>
-                ) : (
-                  t('scorebook:practice', 'Practice')
-                )}
-              </span>
-            </Button>
-          )}
-
           {/* Metronome Controls - Vertical */}
           {!showAdvancedMetronome && (
             <div className="flex flex-col items-center gap-2">
@@ -527,38 +414,6 @@ export default function ScoreControls() {
               <div className="h-px w-full bg-morandi-stone-200" />
             </>
           )}
-          {/* Practice Tracking Toggle */}
-          {isAuthenticated && (
-            <div className="w-full">
-              <Button
-                onClick={() => (isRecording ? stopPractice() : startPractice())}
-                variant={isRecording ? 'danger' : 'secondary'}
-                fullWidth
-                className="flex flex-col items-center gap-1 py-2"
-              >
-                <div
-                  className={cn(
-                    'w-3 h-3 rounded-full',
-                    isRecording ? 'bg-white animate-pulse' : 'bg-red-500'
-                  )}
-                />
-                <span className="text-xs font-medium">
-                  {isRecording ? (
-                    <>
-                      {t('scorebook:recording', 'Recording')}
-                      <div className="text-xs">
-                        {isTracking ? formattedTime : formatTime(elapsedTime)}
-                      </div>
-                    </>
-                  ) : (
-                    t('scorebook:practice', 'Practice')
-                  )}
-                </span>
-              </Button>
-            </div>
-          )}
-
-          <div className="h-px w-full bg-morandi-stone-200" />
 
           {/* Metronome Controls */}
           {!showAdvancedMetronome && (
@@ -775,17 +630,6 @@ export default function ScoreControls() {
           onTripleClick={handleAdvancedMetronomeTripleClick}
         />
       )}
-
-      {/* Practice Summary Modal */}
-      <PracticeSummaryModal
-        isOpen={showSummary}
-        onClose={dismissSummary}
-        onSave={confirmSave}
-        onDiscard={dismissSummary}
-        duration={pendingSession?.duration || 0}
-        metadata={pendingSession?.metadata || {}}
-        title={t('common:practice.practiceSummary')}
-      />
     </>
   )
 }

--- a/frontendv2/src/stores/__tests__/scoreStore.test.ts
+++ b/frontendv2/src/stores/__tests__/scoreStore.test.ts
@@ -1,37 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { useScoreStore } from '../scoreStore'
-import { useLogbookStore } from '../logbookStore'
-
-// Mock functions
-const mockStartPractice = vi.fn()
-const mockStopPractice = vi.fn(() => ({
-  scoreId: 'test-score-1',
-  scoreTitle: 'Test Score',
-  scoreComposer: 'Test Composer',
-  duration: 120,
-  startTime: new Date(),
-  endTime: new Date(),
-}))
-
-// Mock the practice store
-vi.mock('../practiceStore', () => ({
-  usePracticeStore: {
-    getState: vi.fn(() => ({
-      startPractice: mockStartPractice,
-      stopPractice: mockStopPractice,
-    })),
-  },
-}))
-
-// Mock the logbook store
-vi.mock('../logbookStore', () => ({
-  useLogbookStore: {
-    getState: vi.fn(() => ({
-      createEntry: vi.fn(),
-    })),
-  },
-}))
 
 describe('scoreStore', () => {
   beforeEach(() => {
@@ -57,35 +26,16 @@ describe('scoreStore', () => {
         thumbnailUrl: '',
         previewPages: 1,
       },
-      isRecording: false,
     })
   })
 
-  it('should stop practice without creating a logbook entry', () => {
+  it('should have initial state', () => {
     const { result } = renderHook(() => useScoreStore())
-    const logbookCreateEntry = vi.spyOn(
-      useLogbookStore.getState(),
-      'createEntry'
-    )
 
-    // Start practice
-    act(() => {
-      result.current.startPractice()
-    })
-
-    expect(result.current.isRecording).toBe(true)
-
-    // Stop practice
-    act(() => {
-      result.current.stopPractice()
-    })
-
-    expect(result.current.isRecording).toBe(false)
-
-    // Verify that logbook entry was NOT created directly
-    expect(logbookCreateEntry).not.toHaveBeenCalled()
-
-    // Verify that practiceStore.stopPractice was called
-    expect(mockStopPractice).toHaveBeenCalled()
+    // Check that the store has the expected properties
+    expect(result.current.currentScore).toBeDefined()
+    expect(result.current.metronomeSettings).toBeDefined()
+    expect(result.current.autoScrollEnabled).toBe(false)
+    expect(result.current.showManagement).toBe(false)
   })
 })

--- a/frontendv2/src/stores/scoreStore.ts
+++ b/frontendv2/src/stores/scoreStore.ts
@@ -1,18 +1,6 @@
 import { create } from 'zustand'
 import { scoreService, type Score } from '../services/scoreService'
 import type { Collection } from '../types/collections'
-import { usePracticeStore } from './practiceStore'
-
-interface PracticeSession {
-  id: string
-  scoreId: string
-  startTime: Date
-  endTime?: Date
-  duration: number // in seconds
-  measuresCompleted: number[]
-  tempo: number
-  notes?: string
-}
 
 interface MetronomeSettings {
   tempo: number
@@ -35,10 +23,6 @@ interface ScoreStore {
   featuredCollections: Collection[]
   userLibrary: Score[]
 
-  // Practice session
-  practiceSession: PracticeSession | null
-  isRecording: boolean
-
   // Metronome
   metronomeSettings: MetronomeSettings
 
@@ -54,11 +38,6 @@ interface ScoreStore {
   setTotalPages: (pages: number) => void
   nextPage: () => void
   previousPage: () => void
-
-  // Practice actions
-  startPractice: () => void
-  stopPractice: () => void
-  updatePracticeProgress: (measure: number) => void
 
   // Metronome actions
   setTempo: (tempo: number) => void
@@ -103,9 +82,6 @@ export const useScoreStore = create<ScoreStore>((set, get) => ({
   userCollections: [],
   featuredCollections: [],
   userLibrary: [],
-
-  practiceSession: null,
-  isRecording: false,
 
   metronomeSettings: {
     tempo: 120,
@@ -182,59 +158,6 @@ export const useScoreStore = create<ScoreStore>((set, get) => ({
     const { currentPage } = get()
     if (currentPage > 1) {
       set({ currentPage: currentPage - 1 })
-    }
-  },
-
-  // Practice actions
-  startPractice: () => {
-    const { currentScore } = get()
-    if (!currentScore) return
-
-    // Get user's instrument preference (default to piano for now)
-    // TODO: Add user instrument preference to profile
-    const instrument = 'piano' as const
-
-    // Start practice in practiceStore
-    usePracticeStore.getState().startPractice(currentScore, instrument)
-
-    // Mark as recording in scoreStore for UI
-    set({ isRecording: true })
-  },
-
-  stopPractice: () => {
-    const { currentScore } = get()
-    if (!currentScore) return
-
-    // Stop practice and get session data
-    const sessionData = usePracticeStore.getState().stopPractice()
-    if (!sessionData) {
-      set({ isRecording: false })
-      return
-    }
-
-    // Note: Logbook entry creation is now handled by the auto-logging module
-    // in ScoreControls component to avoid duplicate entries
-
-    set({ isRecording: false })
-  },
-
-  updatePracticeProgress: (measure: number) => {
-    const { practiceSession } = get()
-    if (
-      !practiceSession ||
-      !practiceSession.measuresCompleted.includes(measure)
-    ) {
-      set({
-        practiceSession: practiceSession
-          ? {
-              ...practiceSession,
-              measuresCompleted: [
-                ...practiceSession.measuresCompleted,
-                measure,
-              ],
-            }
-          : null,
-      })
     }
   },
 


### PR DESCRIPTION
## Summary
- Removes the incomplete Practice button from the score viewing page
- Cleans up all associated practice tracking code that was specific to score viewing
- Applies consistent header padding from PR #487

## Changes Made

### UI Changes
- **Removed Practice button** from ScoreControls component (both mobile and desktop views)
- **Applied consistent padding** to match the compact UI style from PR #487

### Code Cleanup
- **scoreStore.ts**: Removed all practice-related state (`isRecording`, `practiceSession`) and functions (`startPractice`, `stopPractice`, `updatePracticeProgress`)
- **ScoreControls.tsx**: Removed Practice button UI and all practice tracking logic
- **Scorebook.tsx**: Removed practice warning modal and session management code
- **Tests**: Updated test suite to reflect removed functionality

## Why This Change?

The Practice button implementation was incomplete and redundant since users already have access to the general practice timer in the sidebar. This removes confusion and simplifies the UI while maintaining all essential functionality.

## Test Plan
- [x] All tests passing
- [x] Linting checks passed
- [x] Build successful
- [x] Score viewing functionality intact
- [x] Metronome controls working
- [x] Page navigation working
- [x] Auto-scroll toggle working

## Screenshots
Before: Practice button visible in score controls
After: Cleaner UI without redundant practice button

Fixes #389

🤖 Generated with [Claude Code](https://claude.ai/code)