### PR TITLE
Fix Analytics tab text truncation in Data section

### DIFF
--- a/frontendv2/src/components/ui/SegmentedControl.tsx
+++ b/frontendv2/src/components/ui/SegmentedControl.tsx
@@ -33,9 +33,9 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
   }
 
   const buttonSizeClasses = {
-    sm: 'px-2 sm:px-3 py-1.5 text-xs',
-    md: 'px-2 sm:px-4 py-2 text-xs sm:text-sm',
-    lg: 'px-4 sm:px-6 py-2.5 text-sm sm:text-base',
+    sm: 'px-3 sm:px-4 py-1.5 text-xs',
+    md: 'px-3 sm:px-5 py-2 text-xs sm:text-sm',
+    lg: 'px-5 sm:px-7 py-2.5 text-sm sm:text-base',
   }
 
   return (
@@ -59,7 +59,7 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
             aria-controls={`${option.value}-panel`}
             onClick={() => onChange(option.value)}
             className={cn(
-              'relative flex-1 inline-flex items-center justify-center gap-1 sm:gap-2 rounded-md font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-morandi-purple-500 min-w-0',
+              'relative flex-1 inline-flex items-center justify-center gap-1 sm:gap-2 rounded-md font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-morandi-purple-500 min-w-fit',
               buttonSizeClasses[size],
               isActive
                 ? 'bg-white dark:bg-gray-900 text-morandi-stone-900 dark:text-white shadow-sm'
@@ -69,7 +69,7 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
             {option.icon && (
               <span className="flex-shrink-0">{option.icon}</span>
             )}
-            <span className="truncate">{option.label}</span>
+            <span className="whitespace-nowrap">{option.label}</span>
           </button>
         )
       })}


### PR DESCRIPTION
## Summary

Resolves Analytics tab text being truncated to "Anal..." in the Data section by improving the SegmentedControl component's width handling and text display.

## Changes Made

- **Replaced `truncate` with `whitespace-nowrap`**: Prevents aggressive text cutting while maintaining single-line display
- **Updated width constraints**: Changed `min-w-0` to `min-w-fit` to allow adequate button width  
- **Enhanced responsive padding**: Increased from `px-2 sm:px-4` to `px-3 sm:px-5` for better text accommodation
- **File modified**: `src/components/ui/SegmentedControl.tsx`

## Testing

✅ **Desktop (1280x720)**: Analytics tab displays full text "Analytics"  
✅ **Mobile (375x667)**: Analytics tab displays full text "Analytics"  
✅ **Cross-browser compatibility**: Tested on modern browsers  
✅ **Multi-language support**: Ready for all supported languages (EN, DE, ES, FR, ZH)  
✅ **Code quality**: All linting and type checking passed  
✅ **Unit tests**: All tests pass  

## Before/After

**Before**: Analytics tab showed "Anal..." (truncated)  
**After**: Analytics tab shows "Analytics" (full text)

## Related Issue

Fixes #489

🤖 Generated with [Claude Code](https://claude.ai/code)