### PR TITLE
fix: align period presets with navigation arrows by removing TimelineNav margin

### DIFF
--- a/frontendv2/src/components/ui/TimelineNav.tsx
+++ b/frontendv2/src/components/ui/TimelineNav.tsx
@@ -32,7 +32,7 @@ export default function TimelineNav({
   }
 
   return (
-    <div className={cn('w-full mb-6', className)}>
+    <div className={cn('w-full', className)}>
       <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-0">
         <div className="flex mr-auto bg-white rounded-lg border border-morandi-stone-300 overflow-hidden">
           {levels.map((level, index) => {


### PR DESCRIPTION
## Summary
Fixes misalignment between year|month|day period selector and navigation arrows in practice reports by removing persistent `mb-6` margin from TimelineNav component.

## Root Cause Analysis
- The `div.w-full.mb-6` element visible in browser dev tools was coming from `TimelineNav.tsx` line 35
- Previous attempts to modify PeriodPresets Card component didn't work because the margin was from a different component
- TimelineNav renders inside LogbookEntryList, appearing in the same view as period presets

## Changes Made
- **File**: `frontendv2/src/components/ui/TimelineNav.tsx`
- **Change**: Removed `mb-6` class from wrapper div 
- **Before**: `<div className={cn('w-full mb-6', className)}>`
- **After**: `<div className={cn('w-full', className)}>`

## Testing
- ✅ Build passes without errors
- ✅ Linting passes without issues  
- ✅ All unit tests pass
- ✅ Pre-commit hooks complete successfully
- ✅ Manual browser testing confirms alignment is fixed

## Screenshots
The persistent `mb-6` margin that was causing misalignment has been removed, allowing the period presets to align properly with navigation arrows.

Closes #502

🤖 Generated with [Claude Code](https://claude.ai/code)