### PR TITLE
fix: resolve multiple logbook UI issues (#512-#516)

### DIFF
--- a/frontendv2/src/components/logbook/LogbookSplitView.tsx
+++ b/frontendv2/src/components/logbook/LogbookSplitView.tsx
@@ -13,6 +13,7 @@ interface LogbookSplitViewProps {
   showTimeline?: boolean
   className?: string
   initialSelectedId?: string
+  hidePieceInfo?: boolean
 }
 
 export function LogbookSplitView({
@@ -21,6 +22,7 @@ export function LogbookSplitView({
   showTimeline = false,
   className = '',
   initialSelectedId,
+  hidePieceInfo = false,
 }: LogbookSplitViewProps) {
   const { t } = useTranslation(['logbook', 'common'])
   const { deleteEntry } = useLogbookStore()
@@ -112,6 +114,7 @@ export function LogbookSplitView({
         onEntryEdit={handleEdit}
         onEntryDelete={handleDelete}
         showTimeline={showTimeline}
+        hidePieceInfo={hidePieceInfo}
       />
     </div>
   )

--- a/frontendv2/src/components/logbook/PracticeLogsList.tsx
+++ b/frontendv2/src/components/logbook/PracticeLogsList.tsx
@@ -16,6 +16,7 @@ interface PracticeLogsListProps {
   onEntryDelete?: (entry: LogbookEntry) => void
   showTimeline?: boolean
   className?: string
+  hidePieceInfo?: boolean
 }
 
 interface GroupedEntries {
@@ -32,6 +33,7 @@ export function PracticeLogsList({
   onEntryDelete,
   showTimeline = false,
   className = '',
+  hidePieceInfo = false,
 }: PracticeLogsListProps) {
   const { t, i18n } = useTranslation(['logbook', 'common'])
   const [selectedLevel, setSelectedLevel] = useState<TimelineLevelType>('week')
@@ -324,14 +326,14 @@ export function PracticeLogsList({
             <p className="text-sm">{t('logbook:emptyDescription')}</p>
           </div>
         ) : (
-          groupedEntries.map(group => (
-            <div key={group.date}>
+          groupedEntries.map((group, groupIndex) => (
+            <div key={group.date} className={groupIndex > 0 ? 'mt-2' : ''}>
               <DateSeparator
                 date={group.date}
                 totalDuration={formatDuration(group.totalDuration)}
               />
 
-              {group.entries.map(entry => (
+              {group.entries.map((entry, entryIndex) => (
                 <CompactEntryRow
                   key={entry.id}
                   entryId={entry.id}
@@ -349,6 +351,10 @@ export function PracticeLogsList({
                     onEntryDelete ? () => onEntryDelete(entry) : undefined
                   }
                   onClick={() => onEntrySelect(entry)}
+                  hidePieceInfo={hidePieceInfo}
+                  className={
+                    entryIndex < group.entries.length - 1 ? 'mb-1' : ''
+                  }
                 />
               ))}
             </div>

--- a/frontendv2/src/components/repertoire/PieceDetailView.tsx
+++ b/frontendv2/src/components/repertoire/PieceDetailView.tsx
@@ -475,7 +475,7 @@ export const PieceDetailView: React.FC<PieceDetailViewProps> = ({
 
       {/* Notes Section */}
       <Card padding="md">
-        <div className="mt-6 pt-6 border-t border-stone-200">
+        <div>
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-sm uppercase tracking-wider text-stone-500">
               {t('repertoire:personalNotes')}
@@ -574,6 +574,7 @@ export const PieceDetailView: React.FC<PieceDetailViewProps> = ({
             onUpdate={handleEntryUpdate}
             showTimeline={false}
             initialSelectedId={selectedSessionId}
+            hidePieceInfo={true}
           />
         ) : (
           <Card padding="lg">

--- a/frontendv2/src/components/ui/CompactEntryRow.tsx
+++ b/frontendv2/src/components/ui/CompactEntryRow.tsx
@@ -32,6 +32,7 @@ interface CompactEntryRowProps {
   onClick?: () => void
   className?: string
   entryId?: string
+  hidePieceInfo?: boolean // Hide piece title/composer
   children?: React.ReactNode // For additional content like piece titles
 }
 
@@ -50,6 +51,7 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
   onClick,
   className,
   entryId,
+  hidePieceInfo = false,
   children,
 }) => {
   const [showNotes, setShowNotes] = useState(false)
@@ -83,15 +85,18 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
   return (
     <div
       className={cn(
-        'border-b border-morandi-stone-200 last:border-b-0',
-        isSelected && 'border-l-4 border-l-morandi-purple-600',
+        'border-b border-morandi-stone-200 last:border-b-0 relative',
         className
       )}
       data-testid="logbook-entry"
       data-entry-id={entryId}
     >
+      {/* Highlight bar that doesn't shift content */}
+      {isSelected && (
+        <div className="absolute left-0 top-0 bottom-0 w-1 bg-morandi-purple-600" />
+      )}
       <div
-        className="p-2 hover:bg-morandi-stone-50 transition-colors group cursor-pointer"
+        className="py-2 px-4 hover:bg-morandi-stone-50 transition-colors group cursor-pointer"
         onClick={e => {
           // Only toggle notes if clicking on the main area, not buttons
           if (notes && !(e.target as HTMLElement).closest('button')) {
@@ -105,17 +110,22 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
         <div className="flex items-start justify-between">
           <div className="flex-1 space-y-1">
             {/* First row: Piece name | Composer name (if available) */}
-            {pieces && pieces.length > 0 && (
-              <div className="flex items-center gap-2">
+            {!hidePieceInfo && pieces && pieces.length > 0 && (
+              <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
                 {pieces.map((piece, index) => (
-                  <div key={index} className="flex items-center gap-2">
-                    <MusicTitle className="text-base">
+                  <div
+                    key={index}
+                    className="flex flex-col sm:flex-row sm:items-center sm:gap-2"
+                  >
+                    <MusicTitle className="text-sm">
                       {toTitleCase(piece.title)}
                     </MusicTitle>
                     {piece.composer && (
                       <>
-                        <span className="text-morandi-stone-400">|</span>
-                        <MusicComposer className="text-sm">
+                        <span className="hidden sm:inline text-morandi-stone-400">
+                          |
+                        </span>
+                        <MusicComposer className="text-xs sm:text-sm text-morandi-stone-600">
                           {toTitleCase(piece.composer)}
                         </MusicComposer>
                       </>
@@ -125,8 +135,8 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
               </div>
             )}
 
-            {/* Second row: Time | Duration | Tags */}
-            <div className="flex items-center gap-3">
+            {/* Second row: Time | Duration | Tags - allow wrapping on mobile */}
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
               <span className="text-sm text-morandi-stone-700 font-medium">
                 {time}
               </span>

--- a/frontendv2/src/components/ui/DateSeparator.tsx
+++ b/frontendv2/src/components/ui/DateSeparator.tsx
@@ -13,12 +13,17 @@ export const DateSeparator: React.FC<DateSeparatorProps> = ({
   className,
 }) => {
   return (
-    <div className={cn('px-4 py-2 bg-gray-50', className)}>
+    <div
+      className={cn(
+        'px-4 py-2.5 bg-gray-100 border-b border-gray-200',
+        className
+      )}
+    >
       <div className="flex items-center gap-3">
-        <span className="text-sm font-bold text-gray-600 whitespace-nowrap">
+        <span className="text-sm font-bold text-gray-700 whitespace-nowrap">
           {date}
         </span>
-        <span className="text-sm text-gray-500 whitespace-nowrap">
+        <span className="text-sm text-gray-600 whitespace-nowrap">
           {totalDuration}
         </span>
         <div className="flex-1 h-px bg-gray-300"></div>


### PR DESCRIPTION
## Summary

This PR addresses 5 UI issues in the logbook entry list that appears across Logbook > Overview, Data > Table, and Pieces > Piece detail pages.

## Issues Fixed

### ✅ Issue #516: Left highlight bar shift
- **Problem**: Selected entry highlight bar caused text to shift right
- **Solution**: Use absolute positioning for selection indicator without affecting layout

### ✅ Issue #515: Mobile overflow
- **Problem**: Tags and buttons overflowed on mobile screens  
- **Solution**: Added `flex-wrap` to allow natural wrapping, stacked piece title/composer vertically on mobile

### ✅ Issue #514: Extra space above NOTE area
- **Problem**: Too much spacing with both padding and border
- **Solution**: Removed redundant `mt-6` and `border-t` from notes section

### ✅ Issue #513: Redundant piece info in Practice History
- **Problem**: Piece title/composer shown in both header and list entries
- **Solution**: Added `hidePieceInfo` prop to conditionally hide duplicate information

### ✅ Issue #512: Better visual hierarchy
- **Problem**: Poor visual separation between days and entries
- **Solution**: 
  - Darker background for date separators (gray-100)
  - Added spacing between entries and day groups
  - Aligned entry content with date separator text
  - Reduced piece title font size

## Testing

- ✅ All unit tests passing (429 tests)
- ✅ TypeScript compilation successful
- ✅ ESLint validation passed
- ✅ Pre-commit hooks passed

## Screenshots

Before/After screenshots provided in the individual issues.

## Breaking Changes

None - all changes maintain backward compatibility.

Fixes #516, #515, #514, #513, #512

🤖 Generated with [Claude Code](https://claude.ai/code)