### PR TITLE
feat: improve UI with dropdown menus and larger typography for detail views

### DIFF
--- a/frontendv2/src/components/repertoire/PieceDetailView.tsx
+++ b/frontendv2/src/components/repertoire/PieceDetailView.tsx
@@ -6,12 +6,14 @@ import { LogPracticeButton } from '@/components/ui/ProtectedButtonFactory'
 import { Card } from '@/components/ui/Card'
 import { Select } from '@/components/ui/Select'
 import {
-  MusicTitle,
-  MusicComposer,
+  MusicTitleLarge,
+  MusicComposerLarge,
   Modal,
   ModalBody,
   ModalFooter,
+  DropdownMenu,
 } from '@/components/ui'
+import type { DropdownMenuItem } from '@/components/ui'
 import { LogbookSplitView } from '@/components/logbook/LogbookSplitView'
 import type { LogbookEntry } from '@/api/logbook'
 import {
@@ -74,6 +76,7 @@ export const PieceDetailView: React.FC<PieceDetailViewProps> = ({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [isRemoving, setIsRemoving] = useState(false)
   const [selectedSessionId] = useState<string | undefined>(undefined)
+  const [showMenu, setShowMenu] = useState(false)
 
   // Note: Modal scroll lock is now handled by the Modal component
   const { updatePieceName, loadEntries } = useLogbookStore()
@@ -364,6 +367,27 @@ export const PieceDetailView: React.FC<PieceDetailViewProps> = ({
     // Refresh if needed
   }, [])
 
+  // Build dropdown menu items
+  const menuItems: DropdownMenuItem[] = [
+    {
+      label: t('common:edit'),
+      onClick: () => setIsEditingPiece(true),
+      icon: <Edit2 className="w-3.5 h-3.5" />,
+    },
+    {
+      label: t('repertoire:removeFromPieces'),
+      onClick: () => {
+        if (sessions.length === 0) {
+          setShowDeleteConfirm(true)
+        } else {
+          setShowRemoveConfirm(true)
+        }
+      },
+      variant: 'danger',
+      icon: <Trash2 className="w-3.5 h-3.5" />,
+    },
+  ]
+
   return (
     <div className="space-y-4">
       {/* Combined Header, Stats, and Notes Card */}
@@ -371,48 +395,26 @@ export const PieceDetailView: React.FC<PieceDetailViewProps> = ({
         {/* Header Section */}
         <div className="flex items-start justify-between mb-4">
           <div className="flex-1">
-            <MusicTitle as="h1" className="text-stone-900">
+            <MusicTitleLarge className="text-stone-900">
               {toTitleCase(item.scoreTitle)}
-            </MusicTitle>
+            </MusicTitleLarge>
             <div>
-              <MusicComposer className="text-stone-600">
+              <MusicComposerLarge className="text-stone-600">
                 {toTitleCase(item.scoreComposer)}
-              </MusicComposer>
+              </MusicComposerLarge>
               {item.catalogNumber && (
                 <span className="text-stone-600"> • {item.catalogNumber}</span>
               )}
             </div>
           </div>
           <div className="flex items-center gap-2 ml-4">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setIsEditingPiece(true)}
-              className="flex items-center gap-2"
-            >
-              <Edit2 className="w-4 h-4" />
-              {t('common:edit')}
-            </Button>
-
-            {/* Piece Management Dropdown */}
-            <div className="relative">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  // Show context menu or dropdown with remove options
-                  if (sessions.length === 0) {
-                    setShowDeleteConfirm(true)
-                  } else {
-                    setShowRemoveConfirm(true)
-                  }
-                }}
-                className="flex items-center gap-2 text-red-600 hover:text-red-700 hover:bg-red-50"
-              >
-                <Trash2 className="w-4 h-4" />
-                {t('repertoire:removeFromPieces')}
-              </Button>
-            </div>
+            <DropdownMenu
+              items={menuItems}
+              isOpen={showMenu}
+              onToggle={() => setShowMenu(!showMenu)}
+              onClose={() => setShowMenu(false)}
+              ariaLabel={t('common:moreOptions')}
+            />
           </div>
         </div>
 

--- a/frontendv2/src/components/ui/CompactEntryRow.tsx
+++ b/frontendv2/src/components/ui/CompactEntryRow.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Edit2,
   Trash2,
@@ -13,6 +14,7 @@ import { cn } from '@/utils/cn'
 import { formatDuration } from '@/utils/dateUtils'
 import { toTitleCase } from '@/utils/textFormatting'
 import { MusicTitle, MusicComposer } from './Typography'
+import { DropdownMenu, type DropdownMenuItem } from './DropdownMenu'
 
 interface CompactEntryRowProps {
   time: string
@@ -54,7 +56,28 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
   hidePieceInfo = false,
   children,
 }) => {
+  const { t } = useTranslation('common')
   const [showNotes, setShowNotes] = useState(false)
+  const [showMenu, setShowMenu] = useState(false)
+
+  // Build menu items
+  const menuItems: DropdownMenuItem[] = []
+  if (onEdit) {
+    menuItems.push({
+      label: t('edit'),
+      onClick: onEdit,
+      icon: <Edit2 className="w-3.5 h-3.5" />,
+    })
+  }
+  if (onDelete) {
+    menuItems.push({
+      label: t('delete'),
+      onClick: onDelete,
+      variant: 'danger',
+      icon: <Trash2 className="w-3.5 h-3.5" />,
+    })
+  }
+
   // Get instrument icon
   const getInstrumentIcon = (instrument?: string) => {
     const iconProps = {
@@ -209,33 +232,16 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
             {children && <div className="mt-1">{children}</div>}
           </div>
 
-          {/* Action buttons */}
-          {(onEdit || onDelete) && (
-            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-              {onEdit && (
-                <button
-                  onClick={e => {
-                    e.stopPropagation()
-                    onEdit()
-                  }}
-                  className="p-1.5 text-morandi-stone-600 hover:text-morandi-stone-800 transition-colors"
-                  aria-label="Edit"
-                >
-                  <Edit2 className="w-4 h-4" />
-                </button>
-              )}
-              {onDelete && (
-                <button
-                  onClick={e => {
-                    e.stopPropagation()
-                    onDelete()
-                  }}
-                  className="p-1.5 text-red-600 hover:text-red-800 transition-colors"
-                  aria-label="Delete"
-                >
-                  <Trash2 className="w-4 h-4" />
-                </button>
-              )}
+          {/* Action menu */}
+          {menuItems.length > 0 && (
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+              <DropdownMenu
+                items={menuItems}
+                isOpen={showMenu}
+                onToggle={() => setShowMenu(!showMenu)}
+                onClose={() => setShowMenu(false)}
+                ariaLabel={t('moreOptions')}
+              />
             </div>
           )}
         </div>

--- a/frontendv2/src/components/ui/DropdownMenu.tsx
+++ b/frontendv2/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,106 @@
+import React, { useRef, useEffect } from 'react'
+import { MoreVertical } from 'lucide-react'
+import { cn } from '@/utils/cn'
+
+export interface DropdownMenuItem {
+  label: string
+  onClick: () => void
+  variant?: 'default' | 'danger'
+  icon?: React.ReactNode
+}
+
+interface DropdownMenuProps {
+  items: DropdownMenuItem[]
+  isOpen: boolean
+  onToggle: () => void
+  onClose: () => void
+  className?: string
+  buttonClassName?: string
+  menuClassName?: string
+  icon?: React.ReactNode
+  ariaLabel?: string
+}
+
+export const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  items,
+  isOpen,
+  onToggle,
+  onClose,
+  className,
+  buttonClassName,
+  menuClassName,
+  icon = <MoreVertical className="w-4 h-4" />,
+  ariaLabel = 'More options',
+}) => {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen, onClose])
+
+  return (
+    <div className={cn('relative', className)} ref={menuRef}>
+      <button
+        onClick={e => {
+          e.stopPropagation()
+          onToggle()
+        }}
+        className={cn(
+          'p-1.5 text-morandi-stone-600 hover:text-morandi-stone-800 hover:bg-morandi-stone-100 rounded-md transition-colors',
+          buttonClassName
+        )}
+        aria-label={ariaLabel}
+      >
+        {icon}
+      </button>
+
+      {isOpen && (
+        <div
+          className={cn(
+            'absolute right-0 top-8 min-w-[160px] bg-white border border-morandi-stone-200 rounded-lg shadow-lg py-1 z-50',
+            'animate-in fade-in slide-in-from-top-1 duration-200',
+            menuClassName
+          )}
+        >
+          {items.map((item, index) => (
+            <React.Fragment key={index}>
+              {index > 0 && items[index - 1].variant !== item.variant && (
+                <hr className="my-1 border-morandi-stone-200" />
+              )}
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  item.onClick()
+                  onClose()
+                }}
+                className={cn(
+                  'w-full text-left px-4 py-2 text-sm transition-colors flex items-center gap-2',
+                  item.variant === 'danger'
+                    ? 'text-red-600 hover:bg-red-50'
+                    : 'text-morandi-stone-700 hover:bg-morandi-stone-50'
+                )}
+              >
+                {item.icon && (
+                  <span className="flex-shrink-0">{item.icon}</span>
+                )}
+                <span>{item.label}</span>
+              </button>
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default DropdownMenu

--- a/frontendv2/src/components/ui/EntryDetailPanel.tsx
+++ b/frontendv2/src/components/ui/EntryDetailPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   X,
@@ -18,7 +18,10 @@ import {
 } from '@tabler/icons-react'
 import { LogbookEntry } from '@/api/logbook'
 import { MusicTitle, MusicComposer } from '@/components/ui'
-import Button from '@/components/ui/Button'
+import {
+  DropdownMenu,
+  type DropdownMenuItem,
+} from '@/components/ui/DropdownMenu'
 import { formatDuration, formatDateSeparator } from '@/utils/dateUtils'
 import { toTitleCase } from '@/utils/textFormatting'
 import { cn } from '@/utils/cn'
@@ -41,6 +44,25 @@ export const EntryDetailPanel: React.FC<EntryDetailPanelProps> = ({
   className,
 }) => {
   const { t, i18n } = useTranslation(['logbook', 'common', 'repertoire'])
+  const [showMenu, setShowMenu] = useState(false)
+
+  // Build menu items
+  const menuItems: DropdownMenuItem[] = []
+  if (entry && onEdit) {
+    menuItems.push({
+      label: t('common:edit'),
+      onClick: () => onEdit(entry),
+      icon: <Edit2 className="w-3.5 h-3.5" />,
+    })
+  }
+  if (entry && onDelete) {
+    menuItems.push({
+      label: t('common:delete'),
+      onClick: () => onDelete(entry),
+      variant: 'danger',
+      icon: <Trash2 className="w-3.5 h-3.5" />,
+    })
+  }
 
   // Get mood icon
   const getMoodIcon = (mood?: string) => {
@@ -101,39 +123,67 @@ export const EntryDetailPanel: React.FC<EntryDetailPanelProps> = ({
       )}
     >
       {/* Header */}
-      <div className="flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">
-        <div className="flex items-center gap-2">
-          {onNavigate && (
-            <>
+      <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 bg-gray-50">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            {onNavigate && (
+              <>
+                <button
+                  onClick={() => onNavigate('prev')}
+                  className="p-1 text-gray-500 hover:text-gray-700 transition-colors flex-shrink-0"
+                  aria-label={t('common:previous')}
+                >
+                  <ChevronLeft className="w-5 h-5" />
+                </button>
+                <button
+                  onClick={() => onNavigate('next')}
+                  className="p-1 text-gray-500 hover:text-gray-700 transition-colors flex-shrink-0"
+                  aria-label={t('common:next')}
+                >
+                  <ChevronRight className="w-5 h-5" />
+                </button>
+              </>
+            )}
+            {/* Display piece title if available, otherwise entry details */}
+            {entry?.pieces && entry.pieces.length > 0 ? (
+              <div className="truncate">
+                <h3 className="text-xl font-semibold text-gray-800 truncate">
+                  {toTitleCase(entry.pieces[0].title)}
+                </h3>
+                {entry.pieces[0].composer && (
+                  <p className="text-sm text-gray-600 truncate">
+                    {toTitleCase(entry.pieces[0].composer)}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <h3 className="text-lg font-semibold text-gray-700">
+                {t('logbook:entryDetails')}
+              </h3>
+            )}
+          </div>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {/* Actions menu */}
+            {menuItems.length > 0 && (
+              <DropdownMenu
+                items={menuItems}
+                isOpen={showMenu}
+                onToggle={() => setShowMenu(!showMenu)}
+                onClose={() => setShowMenu(false)}
+                ariaLabel={t('common:moreOptions')}
+              />
+            )}
+            {onClose && (
               <button
-                onClick={() => onNavigate('prev')}
+                onClick={onClose}
                 className="p-1 text-gray-500 hover:text-gray-700 transition-colors"
-                aria-label={t('common:previous')}
+                aria-label={t('common:close')}
               >
-                <ChevronLeft className="w-5 h-5" />
+                <X className="w-5 h-5" />
               </button>
-              <button
-                onClick={() => onNavigate('next')}
-                className="p-1 text-gray-500 hover:text-gray-700 transition-colors"
-                aria-label={t('common:next')}
-              >
-                <ChevronRight className="w-5 h-5" />
-              </button>
-            </>
-          )}
-          <h3 className="font-semibold text-gray-700">
-            {t('logbook:entryDetails')}
-          </h3>
+            )}
+          </div>
         </div>
-        {onClose && (
-          <button
-            onClick={onClose}
-            className="p-1 text-gray-500 hover:text-gray-700 transition-colors"
-            aria-label={t('common:close')}
-          >
-            <X className="w-5 h-5" />
-          </button>
-        )}
       </div>
 
       {/* Content - scrollable with tighter spacing */}
@@ -285,36 +335,6 @@ export const EntryDetailPanel: React.FC<EntryDetailPanelProps> = ({
           </div>
         )}
       </div>
-
-      {/* Actions - directly at bottom without extra spacing */}
-      {(onEdit || onDelete) && (
-        <div className="flex-shrink-0 p-3 pt-2 border-t border-gray-200">
-          <div className="flex gap-2">
-            {onEdit && (
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => onEdit(entry)}
-                className="flex-1 flex items-center justify-center gap-1.5"
-              >
-                <Edit2 className="w-3.5 h-3.5" />
-                {t('common:edit')}
-              </Button>
-            )}
-            {onDelete && (
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={() => onDelete(entry)}
-                className="flex-1 flex items-center justify-center gap-1.5"
-              >
-                <Trash2 className="w-3.5 h-3.5" />
-                {t('common:delete')}
-              </Button>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontendv2/src/components/ui/Typography.tsx
+++ b/frontendv2/src/components/ui/Typography.tsx
@@ -14,7 +14,9 @@ type TypographyVariant =
   | 'body-sm'
   | 'caption'
   | 'music-title'
+  | 'music-title-large'
   | 'music-composer'
+  | 'music-composer-large'
   | 'music-metadata'
 
 // Font family types
@@ -47,7 +49,10 @@ const variantStyles: Record<TypographyVariant, string> = {
   // Music-specific typography (use Noto Serif for musical content)
   'music-title':
     'font-serif text-sm sm:text-base font-medium text-gray-900 leading-tight',
+  'music-title-large':
+    'font-serif text-xl sm:text-2xl font-medium text-gray-900 leading-tight',
   'music-composer': 'font-serif text-xs sm:text-sm text-gray-700',
+  'music-composer-large': 'font-serif text-base sm:text-lg text-gray-700',
   'music-metadata': 'font-inter text-sm text-gray-600',
 }
 
@@ -65,7 +70,9 @@ const defaultElements: Record<TypographyVariant, keyof JSX.IntrinsicElements> =
     'body-sm': 'p',
     caption: 'span',
     'music-title': 'h3',
+    'music-title-large': 'h1',
     'music-composer': 'p',
+    'music-composer-large': 'p',
     'music-metadata': 'span',
   }
 
@@ -120,6 +127,26 @@ export const MusicMetadata = ({
   ...props
 }: Omit<TypographyProps, 'variant'>) => (
   <Typography variant="music-metadata" className={className} {...props}>
+    {children}
+  </Typography>
+)
+
+export const MusicTitleLarge = ({
+  children,
+  className,
+  ...props
+}: Omit<TypographyProps, 'variant'>) => (
+  <Typography variant="music-title-large" className={className} {...props}>
+    {children}
+  </Typography>
+)
+
+export const MusicComposerLarge = ({
+  children,
+  className,
+  ...props
+}: Omit<TypographyProps, 'variant'>) => (
+  <Typography variant="music-composer-large" className={className} {...props}>
     {children}
   </Typography>
 )

--- a/frontendv2/src/components/ui/index.ts
+++ b/frontendv2/src/components/ui/index.ts
@@ -35,6 +35,9 @@ export { default as SplitButton } from './SplitButton'
 
 export { default as TimelineNav } from './TimelineNav'
 
+export { DropdownMenu } from './DropdownMenu'
+export type { DropdownMenuItem } from './DropdownMenu'
+
 export { Tabs } from './Tabs'
 
 export { SegmentedControl } from './SegmentedControl'
@@ -45,6 +48,8 @@ export {
   MusicTitle,
   MusicComposer,
   MusicMetadata,
+  MusicTitleLarge,
+  MusicComposerLarge,
 } from './Typography'
 export type { TypographyProps } from './Typography'
 

--- a/frontendv2/src/locales/de/common.json
+++ b/frontendv2/src/locales/de/common.json
@@ -308,5 +308,6 @@
     "list": "Liste"
   },
   "warning": "Warnung",
-  "yes": "Ja"
+  "yes": "Ja",
+  "moreOptions": "Weitere Optionen"
 }

--- a/frontendv2/src/locales/en/common.json
+++ b/frontendv2/src/locales/en/common.json
@@ -146,6 +146,7 @@
     "september": "September"
   },
   "more": "More",
+  "moreOptions": "More options",
   "music": {
     "lesson": "Lesson",
     "notes": {

--- a/frontendv2/src/locales/es/common.json
+++ b/frontendv2/src/locales/es/common.json
@@ -308,5 +308,6 @@
     "list": "Lista"
   },
   "warning": "Advertencia",
-  "yes": "Sí"
+  "yes": "Sí",
+  "moreOptions": "Más opciones"
 }

--- a/frontendv2/src/locales/fr/common.json
+++ b/frontendv2/src/locales/fr/common.json
@@ -308,5 +308,6 @@
     "list": "Liste"
   },
   "warning": "Avertissement",
-  "yes": "Oui"
+  "yes": "Oui",
+  "moreOptions": "Plus d'options"
 }

--- a/frontendv2/src/locales/zh-CN/common.json
+++ b/frontendv2/src/locales/zh-CN/common.json
@@ -308,5 +308,6 @@
     "list": "列表"
   },
   "warning": "警告",
-  "yes": "是"
+  "yes": "是",
+  "moreOptions": "更多选项"
 }

--- a/frontendv2/src/locales/zh-TW/common.json
+++ b/frontendv2/src/locales/zh-TW/common.json
@@ -308,5 +308,6 @@
     "list": "清單"
   },
   "warning": "警告",
-  "yes": "是"
+  "yes": "是",
+  "moreOptions": "更多選項"
 }


### PR DESCRIPTION
## Summary

This PR improves the UI by replacing inline Edit/Delete buttons with dropdown menus and enhancing typography in detail views.

### Changes Made

- ✨ **Added reusable DropdownMenu component** with click-outside handling
- 🔄 **Replaced inline Edit/Delete buttons** with ellipsis menu in:
  - CompactEntryRow (logbook entries) 
  - EntryDetailPanel (entry detail view)
  - PieceDetailView (repertoire detail view)
- 🌐 **Full i18n support** for dropdown menus (6 languages)
- 📝 **Enhanced typography** for piece detail views:
  - MusicTitleLarge: text-xl/2xl for prominent headers
  - MusicComposerLarge: text-base/lg for better readability
- 🎨 **Improved visual hierarchy** in repertoire detail view

### Issues Fixed

- Fixes #530: Prevents accidental delete taps while scrolling
- Fixes #531: Enhances title prominence in detail panels

### Screenshots

**Before:**
- Inline Edit/Delete buttons were too prominent
- Small title font in detail views
- Risk of accidental taps while scrolling

**After:**
- Clean ellipsis menu pattern
- Larger, more prominent titles
- Better mobile UX

### Testing

- ✅ All unit tests passing
- ✅ TypeScript type checking passed
- ✅ ESLint no errors
- ✅ Pre-commit hooks passed
- ✅ Tested on mobile and desktop viewports

### Translation Status

All translations complete:
- 🇺🇸 English
- 🇪🇸 Spanish  
- 🇫🇷 French
- 🇩🇪 German
- 🇹🇼 Traditional Chinese
- 🇨🇳 Simplified Chinese

🤖 Generated with [Claude Code](https://claude.ai/code)