### PR TITLE
fix: separate piece title and composer on mobile UI

### DIFF
--- a/frontendv2/src/components/ManualEntryForm.tsx
+++ b/frontendv2/src/components/ManualEntryForm.tsx
@@ -432,20 +432,41 @@ export default function ManualEntryForm({
                 value: 'technique',
                 label: t('logbook:entry.typeOptions.technique'),
               },
-            ].map(option => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => setType(option.value as LogbookEntry['type'])}
-                className={`px-3 py-2 text-sm font-medium rounded-lg transition-all ${
-                  type === option.value
-                    ? 'bg-morandi-sage-500 text-white'
-                    : 'bg-white border border-morandi-stone-300 text-morandi-stone-600 hover:bg-morandi-stone-100'
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
+            ].map(option => {
+              // Define distinct background colors for each activity type
+              const getButtonStyles = () => {
+                if (type !== option.value) {
+                  // Inactive state - keep consistent
+                  return 'bg-white border border-morandi-stone-300 text-morandi-stone-600 hover:bg-morandi-stone-100'
+                }
+                // Active state - distinct colors for each type
+                switch (option.value) {
+                  case 'lesson':
+                    return 'bg-morandi-purple-500 text-white border-morandi-purple-600'
+                  case 'practice':
+                    return 'bg-morandi-sage-500 text-white border-morandi-sage-600'
+                  case 'technique':
+                    return 'bg-morandi-sand-500 text-white border-morandi-sand-600'
+                  case 'performance':
+                    return 'bg-morandi-blush-500 text-white border-morandi-blush-600'
+                  case 'rehearsal':
+                    return 'bg-morandi-stone-500 text-white border-morandi-stone-600'
+                  default:
+                    return 'bg-morandi-sage-500 text-white'
+                }
+              }
+
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setType(option.value as LogbookEntry['type'])}
+                  className={`px-3 py-2 text-sm font-medium rounded-lg transition-all ${getButtonStyles()}`}
+                >
+                  {option.label}
+                </button>
+              )
+            })}
           </div>
         </div>
 

--- a/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
+++ b/frontendv2/src/components/repertoire/FocusedRepertoireItem.tsx
@@ -5,7 +5,7 @@ import { formatDuration, capitalizeTimeString } from '@/utils/dateUtils'
 import { toTitleCase } from '@/utils/textFormatting'
 import { RepertoireItem, RepertoireStatus } from '@/api/repertoire'
 import { Goal } from '@/api/goals'
-import { MusicTitle } from '@/components/ui'
+import { MusicTitle, MusicComposer } from '@/components/ui'
 
 interface RecentPractice {
   timestamp: number
@@ -92,14 +92,13 @@ export const FocusedRepertoireItem: React.FC<FocusedRepertoireItemProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex flex-col gap-2">
             {/* Title and Composer */}
-            <div>
-              <MusicTitle
-                as="h3"
-                className="text-base break-words text-stone-900"
-              >
-                {toTitleCase(item.scoreComposer)} -{' '}
+            <div className="flex flex-col gap-0.5">
+              <MusicTitle as="h3" className="break-words">
                 {toTitleCase(item.scoreTitle)}
               </MusicTitle>
+              <MusicComposer as="div" className="break-words">
+                {toTitleCase(item.scoreComposer)}
+              </MusicComposer>
             </div>
 
             {/* Metadata and Actions Row */}

--- a/frontendv2/src/components/repertoire/RepertoireCard.tsx
+++ b/frontendv2/src/components/repertoire/RepertoireCard.tsx
@@ -172,24 +172,19 @@ export function RepertoireCard({ item, onEditSession }: RepertoireCardProps) {
               onClick={() => setIsExpanded(!isExpanded)}
               className="flex-1 text-left group cursor-pointer min-w-0" // min-w-0 allows flex child to shrink
             >
-              <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 group-hover:text-stone-700 transition-colors duration-200">
-                <div className="flex items-center gap-1 sm:gap-2 min-w-0 flex-wrap">
-                  <MusicTitle
-                    as="span"
-                    className="text-sm text-stone-900 group-hover:text-stone-700 break-words leading-tight"
-                  >
-                    {toTitleCase(item.scoreTitle)}
-                  </MusicTitle>
-                  <span className="text-stone-600 flex-shrink-0 text-sm">
-                    -
-                  </span>
-                  <MusicComposer
-                    as="span"
-                    className="text-sm text-stone-700 group-hover:text-stone-600 break-words leading-tight"
-                  >
-                    {toTitleCase(item.scoreComposer)}
-                  </MusicComposer>
-                </div>
+              <div className="flex flex-col gap-0.5">
+                <MusicTitle
+                  as="div"
+                  className="text-sm sm:text-base text-stone-900 group-hover:text-stone-700 break-words leading-tight"
+                >
+                  {toTitleCase(item.scoreTitle)}
+                </MusicTitle>
+                <MusicComposer
+                  as="div"
+                  className="text-sm text-stone-700 group-hover:text-stone-600 break-words leading-tight"
+                >
+                  {toTitleCase(item.scoreComposer)}
+                </MusicComposer>
               </div>
             </button>
 

--- a/frontendv2/src/components/ui/CompactEntryRow.tsx
+++ b/frontendv2/src/components/ui/CompactEntryRow.tsx
@@ -140,17 +140,20 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
                     key={index}
                     className="flex flex-col sm:flex-row sm:items-center sm:gap-2"
                   >
-                    <MusicTitle>{toTitleCase(piece.title)}</MusicTitle>
-                    {piece.composer && (
-                      <>
-                        <span className="hidden sm:inline text-morandi-stone-400">
-                          |
-                        </span>
-                        <MusicComposer className="text-morandi-stone-600">
-                          {toTitleCase(piece.composer)}
-                        </MusicComposer>
-                      </>
-                    )}
+                    {/* Mobile: Two lines for title and composer */}
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                      <MusicTitle>{toTitleCase(piece.title)}</MusicTitle>
+                      {piece.composer && (
+                        <>
+                          <span className="hidden sm:inline text-morandi-stone-400">
+                            |
+                          </span>
+                          <MusicComposer className="block sm:inline text-morandi-stone-600">
+                            {toTitleCase(piece.composer)}
+                          </MusicComposer>
+                        </>
+                      )}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -174,11 +177,27 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
               )}
               {type && (
                 <span
-                  className={`px-2 py-0.5 text-xs rounded-full ${
-                    type.toLowerCase() === 'status_change'
-                      ? 'bg-orange-200 text-orange-800'
-                      : 'bg-morandi-sage-100 text-morandi-stone-700'
-                  }`}
+                  className={`px-2 py-0.5 text-xs rounded-full ${(() => {
+                    const typeLower = type.toLowerCase()
+                    if (typeLower === 'status_change') {
+                      return 'bg-orange-200 text-orange-800'
+                    }
+                    // Match the color scheme from ManualEntryForm
+                    switch (typeLower) {
+                      case 'lesson':
+                        return 'bg-morandi-purple-100 text-morandi-purple-700'
+                      case 'practice':
+                        return 'bg-morandi-sage-100 text-morandi-sage-700'
+                      case 'technique':
+                        return 'bg-morandi-sand-100 text-morandi-sand-700'
+                      case 'performance':
+                        return 'bg-morandi-blush-100 text-morandi-blush-700'
+                      case 'rehearsal':
+                        return 'bg-morandi-stone-200 text-morandi-stone-700'
+                      default:
+                        return 'bg-morandi-sage-100 text-morandi-stone-700'
+                    }
+                  })()}`}
                 >
                   {type}
                 </span>

--- a/frontendv2/src/tests/unit/components/repertoire/FocusedRepertoireItem.test.tsx
+++ b/frontendv2/src/tests/unit/components/repertoire/FocusedRepertoireItem.test.tsx
@@ -53,7 +53,8 @@ describe('FocusedRepertoireItem', () => {
 
       render(<FocusedRepertoireItem item={item} />)
 
-      expect(screen.getByText(/Test Composer.*Test Piece/)).toBeInTheDocument()
+      expect(screen.getByText('Test Piece')).toBeInTheDocument()
+      expect(screen.getByText('Test Composer')).toBeInTheDocument()
       expect(screen.getByText('repertoire:status.learning')).toBeInTheDocument()
       expect(screen.getByText('120 min')).toBeInTheDocument()
     })


### PR DESCRIPTION
## Summary
- Separated piece title and composer onto separate lines for better mobile readability
- Updated multiple components to use consistent Typography system
- Added distinct colors for different activity types

## Changes Made
1. **FocusedRepertoireItem.tsx**: Separated composer and title that were previously concatenated with a dash
2. **RepertoireCard.tsx**: Applied same separation pattern for consistency  
3. **CompactEntryRow.tsx**: Improved mobile display of pieces
4. **ManualEntryForm.tsx**: Added distinct colors for different activity types (lesson, practice, technique, performance, rehearsal)
5. **Test updates**: Fixed tests to match new UI layout

## Issues Fixed
- Fixes #540 - Mobile UI: Piece name and composer should be on separate lines
- Fixes #542 - Mobile UI improvement for repertoire display

## Test Plan
- [x] Linter passes with no new errors
- [x] Build completes successfully  
- [x] Unit tests updated and passing
- [ ] Manual testing on mobile devices
- [ ] Visual verification that title and composer appear on separate lines

## Screenshots
Before: Composer and title on same line with dash separator
After: Title on first line, composer on second line with proper Typography components

🤖 Generated with [Claude Code](https://claude.ai/code)