### PR TITLE
fix(i18n): restore background colors for type badges in all languages

### DIFF
--- a/frontendv2/src/components/LogbookEntryList.tsx
+++ b/frontendv2/src/components/LogbookEntryList.tsx
@@ -401,7 +401,7 @@ export default function LogbookEntryList({
                   entryId={entry.id}
                   time={formatTime(entry.timestamp)}
                   duration={entry.duration}
-                  type={t(`common:music.${entry.type.toLowerCase()}`)}
+                  type={entry.type}
                   instrument={entry.instrument || undefined}
                   isSelected={selectedEntry?.id === entry.id}
                   onEdit={() => handleEdit(entry)}

--- a/frontendv2/src/components/logbook/PracticeLogsList.tsx
+++ b/frontendv2/src/components/logbook/PracticeLogsList.tsx
@@ -339,11 +339,7 @@ export function PracticeLogsList({
                   entryId={entry.id}
                   time={formatTime(entry.timestamp)}
                   duration={entry.duration}
-                  type={
-                    entry.type === 'status_change'
-                      ? 'status_change'
-                      : t(`common:music.${entry.type.toLowerCase()}`)
-                  }
+                  type={entry.type}
                   instrument={entry.instrument || undefined}
                   pieces={entry.pieces}
                   notes={entry.notes}

--- a/frontendv2/src/components/ui/CompactEntryRow.tsx
+++ b/frontendv2/src/components/ui/CompactEntryRow.tsx
@@ -207,7 +207,7 @@ export const CompactEntryRow: React.FC<CompactEntryRowProps> = ({
                     }
                   })()}`}
                 >
-                  {type}
+                  {type === 'status_change' ? type : t(`common:music.${type}`)}
                 </span>
               )}
               {instrument && (

--- a/frontendv2/tailwind.config.js
+++ b/frontendv2/tailwind.config.js
@@ -188,5 +188,27 @@ export default {
     'bg-morandi-navy-400', // Learning (medium)
     'bg-morandi-navy-300', // Planned (lightest)
     'bg-gray-300', // Dropped/default
+    // Technique tag colors
+    'bg-morandi-blush-100',
+    'bg-morandi-peach-100',
+    'bg-sand-100',
+    'text-sand-800',
+    // Summary stats colors
+    'bg-morandi-stone-50',
+    'bg-morandi-stone-100',
+    'bg-morandi-rose-50',
+    // Type badge colors for practice entry types
+    'bg-morandi-purple-200',
+    'text-morandi-purple-800',
+    'bg-morandi-sage-100',
+    'text-morandi-sage-700',
+    'bg-morandi-sand-100',
+    'text-morandi-sand-700',
+    'bg-morandi-blush-100',
+    'text-morandi-blush-700',
+    'bg-morandi-stone-200',
+    'text-morandi-stone-700',
+    'bg-orange-200',
+    'text-orange-800',
   ],
 }


### PR DESCRIPTION
## Summary
Fixes #581 - Type badges (lesson, practice, etc.) now display correct background colors in all language versions.

## Problem
- Type badges lost their distinct background colors when switching to non-English languages
- "Lesson" badges appeared with default color instead of purple in Spanish/French/etc.
- Root cause: Color logic was comparing translated strings ("Lección") against English values ("lesson")

## Solution
- Pass raw English type values to `CompactEntryRow` for color selection
- Move translation logic into `CompactEntryRow` for display only
- Add all badge colors to Tailwind safelist to prevent CSS purging in production

## Changes
- `PracticeLogsList.tsx`: Pass raw `entry.type` instead of translated value
- `LogbookEntryList.tsx`: Pass raw `entry.type` instead of translated value  
- `CompactEntryRow.tsx`: Translate type for display while using raw value for colors
- `tailwind.config.js`: Add all type badge background/text colors to safelist

## Testing
- [x] Verified lesson badges show purple background in English
- [x] Verified lesson badges show purple background in Spanish/French/German/Chinese
- [x] All type badges maintain distinct colors across languages
- [x] Badge text displays in selected language

🤖 Generated with [Claude Code](https://claude.ai/code)