### PR TITLE
docs: clarify planning tab reminders and progress UI

### DIFF
--- a/docs/specs/05-features/practice-planning.md
+++ b/docs/specs/05-features/practice-planning.md
@@ -56,6 +56,47 @@ Introduce structured planning layers on top of the existing logbook so musicians
 - **Reminder logic**: Introduce a derived `nextActionableOccurrence` helper that prioritizes overdue, then due-today, then upcoming sessions. The UI consumes this helper to populate the hero reminders panel and to display subtle badges (e.g., “Due today”) inline with progress rails.
 - **Accessibility & responsiveness**: Progress rails collapse into stacked rows on mobile while preserving the same data points. Instrument glyphs (replacing the sample airplane) come from the existing icon set and always include accessible labels.
 
+### Outstanding work & suggested tickets
+
+#### Surface due practice-plan sessions in planning tab
+
+**Goal**: Prioritize reminders inside the Planning tab so musicians immediately see what needs attention, paired with clear progress context per plan.
+
+**Suggested ticket**: _“Surface actionable practice-plan reminders in the Planning tab”_
+
+**Sub-tasks**
+
+1. **Hero reminder carousel** – Introduce a top-of-tab module that lists the next actionable occurrences in priority order (overdue → due today → upcoming). Each reminder shows start window, instrument icon, and CTA (e.g., “Start session”). (`frontendv2/src/components/practice-planning/PlanningView.tsx`, `frontendv2/src/components/practice-planning/PlanReminderCard.tsx`)
+2. **Plan progress rail component** – Create a reusable progress bar that visualizes completed, today, and remaining counts with tokens (`--color-success-500`, `--color-accent-500`, `--color-muted-300`). Include accessible labels and mobile stacking rules. (`frontendv2/src/components/practice-planning/PlanProgressRail.tsx`, shared styles)
+3. **Planning selectors + reminders logic** – Extend `usePlanningStore` with derived selectors: `completedOccurrences`, `dueTodayOccurrences`, `upcomingOccurrences`, and `nextActionableOccurrence`. Ensure timezone-aware bucketing, recurrence expansion, and optimistic updates when occurrences complete. (`frontendv2/src/stores/planningStore.ts`, related tests)
+4. **Reminder badge copy + analytics hooks** – Emit lightweight analytics events (viewed reminder, started session) and finalize copy guidelines consistent with Mirubato tone. Update empty states to reference the new hero module. (`frontendv2/src/lib/analytics/planning.ts`, `frontendv2/src/components/practice-planning/PlanningEmptyState.tsx`)
+
+#### Integrate planning metrics into analytics
+
+**Goal**: Blend planned targets, actual completions, and adherence metrics so analytics surfaces progress toward planned curricula.
+
+**Suggested ticket**: _“Blend planning targets into practice analytics dashboards”_
+
+**Sub-tasks**
+
+1. **Data aggregation layer** – Extend the analytics selector/hook (`frontendv2/src/hooks/useEnhancedAnalytics.ts`) to join `plan_occurrence` check-in metrics and linked `logbook_entry` data, producing adherence %, completion streaks, and forecasted load.
+2. **Visualization updates** – Refresh analytics components to surface new KPIs (e.g., adherence trend sparkline, workload forecast). Coordinate with Planning tab metrics for consistent terminology. (`frontendv2/src/components/practice-planning/PlanningAnalyticsPanel.tsx`, `frontendv2/src/components/practice-reports/EnhancedReports.tsx`)
+3. **Backend schema alignment** – Ensure sync payloads expose necessary check-in metrics and targets. Update API validation and migrations if new fields are required. (`api/src/schemas/entities.ts`, `api/src/api/handlers/sync.ts`, `api/src/utils/validation.ts`)
+4. **Testing + telemetry** – Add unit tests for analytics calculations (edge cases: missing check-ins, skipped sessions) and confirm telemetry events capture adherence insights without PII leakage. (`frontendv2/src/hooks/__tests__/useEnhancedAnalytics.test.ts`, analytics logging utilities)
+
+#### Build plan template publishing & adoption
+
+**Goal**: Enable tutors to publish reusable plan templates and learners to browse, preview, and adopt them into personal planning.
+
+**Suggested ticket**: _“Introduce tutor practice plan templates and sharing flows”_
+
+**Sub-tasks**
+
+1. **Template data model** – Add `plan_template` entity definitions, migrations, and sync handlers with versioning, visibility controls, and author metadata. (`api/src/schemas/entities.ts`, `api/src/api/handlers/sync.ts`, database migrations)
+2. **Tutor publishing UI** – Build tutor-facing flows to author templates, attach metadata (instrument, level, duration), and manage visibility. (`frontendv2/src/components/practice-planning/templates/TemplatePublisherModal.tsx`, related forms)
+3. **Learner browsing & adoption** – Create a template gallery with filtering, preview details, and import wizard that clones templates into `practice_plan` instances with optional parameter prompts. (`frontendv2/src/components/practice-planning/templates/TemplateGallery.tsx`, `frontendv2/src/components/practice-planning/templates/TemplateImportWizard.tsx`)
+4. **Sharing + audit instrumentation** – Track template usage, enforce permission checks, and audit adoption events. Ensure sync conflicts resolve cleanly when templates update. (`frontendv2/src/stores/planningStore.ts`, telemetry hooks, sync-worker broadcasting)
+
 ### Data Model
 
 | Entity                    | Key Fields                                                                                                                                                                                                                                                                                           | Notes                                                                                                                                       |


### PR DESCRIPTION
## Summary
- shift the Phase 2 reminder requirement from the logbook overview to a richer Planning tab experience
- document a Planning tab visual refresh with hero reminders, per-plan progress rails, and supporting data selectors

## Testing
- pnpm -r --workspace-concurrency=2 run test:unit -- --watchAll=false
- pnpm -r run type-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e03b3487483218b405e7ceb99e4cf)