### PR TITLE
feat: refresh reminder icons and tests

### DIFF
--- a/frontendv2/src/components/practice-planning/PlanReminderCard.tsx
+++ b/frontendv2/src/components/practice-planning/PlanReminderCard.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  IconPiano,
-  IconGuitarPick,
-  IconMusic,
-  IconMicrophone,
-  IconLayoutGrid,
-  IconCircle,
-} from '@tabler/icons-react'
+  Piano,
+  Guitar,
+  Music,
+  MicVocal,
+  LayoutGrid,
+  Drum,
+  type LucideIcon,
+} from 'lucide-react'
 import type { PracticePlan, PlanOccurrence } from '@/api/planning'
 import { Button, Tag, Typography } from '@/components/ui'
 import { cn } from '@/utils/cn'
@@ -24,23 +25,39 @@ interface PlanReminderCardProps {
   onOpenPlan?: (plan: PracticePlan, occurrence: PlanOccurrence) => void
 }
 
-const instrumentIcons: Record<string, JSX.Element> = {
-  piano: <IconPiano size={20} stroke={1.6} />,
-  guitar: <IconGuitarPick size={20} stroke={1.6} />,
-  violin: <IconMusic size={20} stroke={1.6} />,
-  viola: <IconMusic size={20} stroke={1.6} />,
-  cello: <IconMusic size={20} stroke={1.6} />,
-  'double-bass': <IconMusic size={20} stroke={1.6} />,
-  flute: <IconMusic size={20} stroke={1.6} />,
-  clarinet: <IconMusic size={20} stroke={1.6} />,
-  saxophone: <IconMusic size={20} stroke={1.6} />,
-  trumpet: <IconMusic size={20} stroke={1.6} />,
-  trombone: <IconMusic size={20} stroke={1.6} />,
-  tuba: <IconMusic size={20} stroke={1.6} />,
-  voice: <IconMicrophone size={20} stroke={1.6} />,
-  organ: <IconPiano size={20} stroke={1.6} />,
-  accordion: <IconLayoutGrid size={20} stroke={1.6} />,
-  percussion: <IconCircle size={20} stroke={1.6} />,
+const ICON_STROKE_WIDTH = 1.6
+
+const instrumentIcons: Record<string, LucideIcon> = {
+  piano: Piano,
+  organ: Piano,
+  guitar: Guitar,
+  violin: Music,
+  viola: Music,
+  cello: Music,
+  'double-bass': Music,
+  flute: Music,
+  clarinet: Music,
+  saxophone: Music,
+  trumpet: Music,
+  trombone: Music,
+  tuba: Music,
+  voice: MicVocal,
+  accordion: LayoutGrid,
+  percussion: Drum,
+}
+
+const renderInstrumentIcon = (instrument?: string) => {
+  const IconComponent =
+    (instrument ? instrumentIcons[instrument] : undefined) ?? Music
+
+  return (
+    <IconComponent
+      aria-hidden="true"
+      className="h-5 w-5 text-current"
+      data-testid="instrument-icon"
+      strokeWidth={ICON_STROKE_WIDTH}
+    />
+  )
 }
 
 const parseDate = (value?: string | null) => {
@@ -153,10 +170,9 @@ const PlanReminderCard = ({
     () => resolveInstrument(plan, fallbackInstrument),
     [plan, fallbackInstrument]
   )
-  const instrumentIcon = instrument ? (
-    (instrumentIcons[instrument] ?? <IconMusic size={20} stroke={1.6} />)
-  ) : (
-    <IconMusic size={20} stroke={1.6} />
+  const instrumentIcon = useMemo(
+    () => renderInstrumentIcon(instrument),
+    [instrument]
   )
 
   const instrumentLabel = instrument
@@ -205,7 +221,10 @@ const PlanReminderCard = ({
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3">
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-morandi-sage-50 text-morandi-sage-700">
+          <div
+            data-testid="instrument-icon-wrapper"
+            className="flex h-11 w-11 items-center justify-center rounded-xl bg-morandi-sage-50 text-morandi-sage-700"
+          >
             {instrumentIcon}
           </div>
           <div className="space-y-1">

--- a/frontendv2/src/components/practice-planning/__tests__/PlanReminderCard.test.tsx
+++ b/frontendv2/src/components/practice-planning/__tests__/PlanReminderCard.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PlanReminderCard from '../PlanReminderCard'
+import type { PracticePlan, PlanOccurrence } from '@/api/planning'
+
+vi.mock('react-i18next', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/tests/mocks/i18n')>(
+      '@/tests/mocks/i18n'
+    )
+  return actual.i18nMock
+})
+
+const basePlan: PracticePlan = {
+  id: 'plan-voice',
+  title: 'Vocal Warmup',
+  type: 'custom',
+  schedule: {
+    kind: 'single',
+    durationMinutes: 20,
+  },
+  visibility: 'private',
+  status: 'active',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+}
+
+const baseOccurrence: PlanOccurrence = {
+  id: 'occ-1',
+  planId: 'plan-voice',
+  status: 'scheduled',
+  scheduledStart: '2025-01-01T09:00:00.000Z',
+  scheduledEnd: '2025-01-01T09:30:00.000Z',
+  segments: [],
+  targets: {},
+  metrics: {},
+  reflectionPrompts: [],
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+}
+
+const buildPlan = (overrides: Partial<PracticePlan> = {}): PracticePlan => ({
+  ...basePlan,
+  ...overrides,
+})
+
+const buildOccurrence = (
+  overrides: Partial<PlanOccurrence> = {}
+): PlanOccurrence => ({
+  ...baseOccurrence,
+  ...overrides,
+})
+
+describe('PlanReminderCard', () => {
+  it('renders Lucide icons that inherit text color for metadata instruments', () => {
+    const plan = buildPlan({
+      metadata: { instrument: 'voice' },
+    })
+
+    render(
+      <PlanReminderCard
+        plan={plan}
+        occurrence={buildOccurrence()}
+        status="due"
+        fallbackInstrument="piano"
+      />
+    )
+
+    const icon = screen.getByTestId('instrument-icon')
+
+    expect(icon.getAttribute('class')).toContain('lucide-mic-vocal')
+    expect(icon.getAttribute('stroke')).toBe('currentColor')
+  })
+
+  it('falls back to the provided instrument when metadata is missing', () => {
+    render(
+      <PlanReminderCard
+        plan={buildPlan({ metadata: undefined })}
+        occurrence={buildOccurrence()}
+        status="due"
+        fallbackInstrument="guitar"
+      />
+    )
+
+    const icon = screen.getByTestId('instrument-icon')
+    expect(icon.getAttribute('class')).toContain('lucide-guitar')
+  })
+
+  it('keeps Morandi palette styles on the icon container for contrast', () => {
+    render(
+      <PlanReminderCard
+        plan={buildPlan({ metadata: { instrument: 'piano' } })}
+        occurrence={buildOccurrence()}
+        status="due"
+        fallbackInstrument="piano"
+      />
+    )
+
+    const iconWrapper = screen.getByTestId('instrument-icon-wrapper')
+
+    expect(iconWrapper.className).toContain('bg-morandi-sage-50')
+    expect(iconWrapper.className).toContain('text-morandi-sage-700')
+  })
+})


### PR DESCRIPTION
## Summary
- swap the reminder card instrument glyphs to lucide-react, keep them aligned with the Morandi palette, and ensure the icons inherit the surrounding text color
- add focused PlanReminderCard tests that verify instrument resolution, fallback behavior, and the Morandi contrast styles so future regressions are caught

## Testing
- `pnpm vitest run src/components/practice-planning/__tests__/PlanReminderCard.test.tsx`
- `pnpm -r --workspace-concurrency=2 run test:unit -- --watchAll=false`
- `pnpm -r run type-check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a38b3155483218509ea548bae39d2)