### PR TITLE
feat(api): support practice plan source templates

### DIFF
--- a/api/src/api/handlers/templates.ts
+++ b/api/src/api/handlers/templates.ts
@@ -87,6 +87,7 @@ templatesHandler.post(
         status: 'active' as const,
         ownerId: userId,
         templateVersion: template.templateVersion,
+        sourceTemplateId: templateId,
         tags: template.tags || [],
         metadata: {
           ...template.metadata,

--- a/api/src/schemas/entities.ts
+++ b/api/src/schemas/entities.ts
@@ -188,6 +188,7 @@ export const PracticePlanSchema = z.object({
   status: PracticePlanStatus.default('draft'),
   ownerId: z.string().optional(),
   templateVersion: z.number().int().optional(),
+  sourceTemplateId: z.string().nullable().optional(),
   tags: z.array(z.string()).optional(),
   metadata: z.record(z.unknown()).optional(),
   createdAt: z.string(),

--- a/sync-worker/src/schemas.ts
+++ b/sync-worker/src/schemas.ts
@@ -120,6 +120,7 @@ export const PracticePlanSchema = z.object({
   status: PracticePlanStatus,
   ownerId: z.string().optional(),
   templateVersion: z.number().int().optional(),
+  sourceTemplateId: z.string().nullable().optional(),
   tags: z.array(z.string()).default([]).optional(),
   metadata: z.record(z.string(), z.unknown()).default({}).optional(),
   createdAt: z.string().datetime(),


### PR DESCRIPTION
## Summary
- add a `sourceTemplateId` field to the practice plan schema so sync payloads can track their originating template
- ensure the sync worker schema and template adoption endpoint both accept and persist the field when creating plans from templates

## Testing
- `pnpm --filter @mirubato/api test -- --runInBand`
- `pnpm -r --workspace-concurrency=2 run test:unit -- --watchAll=false`
- `pnpm -r run type-check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a549f0008832199c113b7c09b8d9c)