### PR TITLE
Allow plan template sync entities

### DIFF
--- a/api/src/api/openapi.ts
+++ b/api/src/api/openapi.ts
@@ -682,6 +682,7 @@ export const openAPISpec = {
                     'goal',
                     'practice_plan',
                     'plan_occurrence',
+                    'plan_template',
                     'user_preferences',
                   ],
                   example: 'logbook_entry',

--- a/api/src/utils/validation.ts
+++ b/api/src/utils/validation.ts
@@ -249,6 +249,7 @@ export const schemas = {
       'goal',
       'practice_plan',
       'plan_occurrence',
+      'plan_template',
       'user_preferences',
     ]),
     data: z.unknown(), // Allow any data structure since sync_data is flexible
@@ -265,6 +266,7 @@ export const schemas = {
           'goal',
           'practice_plan',
           'plan_occurrence',
+          'plan_template',
           'user_preferences',
         ]),
         data: z.unknown(), // Allow any data structure since sync_data is flexible


### PR DESCRIPTION
## Summary
- allow `plan_template` entities through the sync validation helpers so plan template payloads are accepted by push/pull/batch endpoints
- document the new entity type in the OpenAPI schema so API consumers see the updated enum

## Testing
- `pnpm exec vitest run src/api/handlers/sync.test.ts`
- `pnpm -r --workspace-concurrency=2 run test:unit -- --watchAll=false`
- `pnpm -r run type-check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a657f12788321bcf4720e4cea0ed6)