### PR TITLE
Allow template adoption to keep focus metadata

### DIFF
--- a/api/src/api/handlers/templates.ts
+++ b/api/src/api/handlers/templates.ts
@@ -17,6 +17,8 @@ const AdoptTemplateSchema = z.object({
   customization: z
     .object({
       title: z.string().optional(),
+      focusAreas: z.array(z.string()).optional(),
+      tags: z.array(z.string()).optional(),
       schedule: z
         .object({
           startDate: z.string().optional(),
@@ -73,13 +75,23 @@ templatesHandler.post(
         ...(customization?.schedule || {}),
       }
 
+      const mergedFocusAreas = Array.from(
+        new Set([
+          ...(template.focusAreas || []),
+          ...(customization?.focusAreas || []),
+        ])
+      )
+      const mergedTags = Array.from(
+        new Set([...(template.tags || []), ...(customization?.tags || [])])
+      )
+
       const newPlan = {
         id: planId,
         user_id: userId,
         title: customTitle,
         description: template.description,
         type: template.type,
-        focusAreas: template.focusAreas || [],
+        focusAreas: mergedFocusAreas,
         techniques: template.techniques || [],
         pieceRefs: template.pieceRefs || [],
         schedule: customSchedule,
@@ -89,7 +101,7 @@ templatesHandler.post(
         templateVersion: template.templateVersion,
         // Ensure downstream clients know which template spawned this plan
         sourceTemplateId: templateId,
-        tags: template.tags || [],
+        tags: mergedTags,
         metadata: {
           ...template.metadata,
           adoptedFrom: templateId,


### PR DESCRIPTION
## Summary
- allow the template adoption payload to include optional `focusAreas` and `tags`
- merge the template and customization metadata when instantiating a new plan so user selections persist

## Testing
- `pnpm -r --workspace-concurrency=2 run test:unit -- --watchAll=false`
- `pnpm -r run type-check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a71ef1e548321973cd0a83acfcd71)