### PR TITLE
Preserve template occurrence segments on adoption

### DIFF
--- a/api/src/api/handlers/templates.test.ts
+++ b/api/src/api/handlers/templates.test.ts
@@ -8,6 +8,7 @@ import type { Variables } from '../middleware'
 const createTemplateRecord = () => ({
   id: 'template_123',
   authorId: 'author_abc',
+  sourcePlanId: 'plan_original',
   title: 'Morning Warmup',
   description: 'A simple routine',
   type: 'custom' as const,
@@ -26,10 +27,53 @@ const createTemplateRecord = () => ({
   templateVersion: 1,
   visibility: 'public',
   adoptionCount: 3,
-  metadata: { difficulty: 'beginner' },
+  metadata: {
+    difficulty: 'beginner',
+    preview: {
+      segments: [
+        {
+          label: 'Preview Warmup',
+          durationMinutes: 5,
+          techniques: ['staccato'],
+          instructions: 'Use light articulation',
+          tempoTargets: { targetBpm: 80 },
+        },
+      ],
+    },
+  },
   publishedAt: '2024-01-01T00:00:00.000Z',
   createdAt: '2024-01-01T00:00:00.000Z',
   updatedAt: '2024-01-01T00:00:00.000Z',
+  deletedAt: null,
+})
+
+const createPlanOccurrenceRecord = () => ({
+  id: 'plan_occ_original',
+  planId: 'plan_original',
+  user_id: 'author_abc',
+  scheduledStart: '2024-01-02T09:00:00.000Z',
+  scheduledEnd: '2024-01-02T09:30:00.000Z',
+  flexWindow: null,
+  recurrenceKey: null,
+  segments: [
+    {
+      label: 'Canonical Warmup',
+      durationMinutes: 15,
+      techniques: ['legato'],
+      instructions: 'Use connected sound',
+      tempoTargets: { targetBpm: 95 },
+    },
+  ],
+  targets: {},
+  reflectionPrompts: [],
+  status: 'scheduled' as const,
+  logEntryId: null,
+  checkIn: undefined,
+  notes: null,
+  reminderState: undefined,
+  metrics: {},
+  createdAt: '2024-01-02T00:00:00.000Z',
+  updatedAt: '2024-01-02T00:00:00.000Z',
   deletedAt: null,
 })
 
@@ -67,6 +111,7 @@ describe('templatesHandler', () => {
   let app: Hono<{ Bindings: Env; Variables: Variables }>
   let mockPrepare: ReturnType<typeof vi.fn>
   let templateFromDb = createTemplateRecord()
+  let planOccurrencesFromDb: { data: string }[]
 
   const createEnv = () => ({
     DB: { prepare: mockPrepare } as unknown as D1Database,
@@ -94,12 +139,26 @@ describe('templatesHandler', () => {
     })
     mockCalculateChecksum.mockResolvedValue('checksum')
     templateFromDb = createTemplateRecord()
+    planOccurrencesFromDb = []
 
-    const mockFirst = vi.fn().mockResolvedValue({
-      data: JSON.stringify(templateFromDb),
-    })
+    const mockFirst = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ data: JSON.stringify(templateFromDb) })
+      )
     const mockBind = vi.fn().mockReturnValue({ first: mockFirst })
-    mockPrepare = vi.fn().mockReturnValue({ bind: mockBind })
+    const mockAll = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ results: planOccurrencesFromDb })
+      )
+    const mockBindOccurrences = vi.fn().mockReturnValue({ all: mockAll })
+    mockPrepare = vi.fn().mockImplementation((query: string) => {
+      if (query.includes("json_extract(data, '$.planId')")) {
+        return { bind: mockBindOccurrences }
+      }
+      return { bind: mockBind }
+    })
 
     app = new Hono<{ Bindings: Env; Variables: Variables }>()
     app.route('/api/templates', templatesHandler)
@@ -126,5 +185,101 @@ describe('templatesHandler', () => {
     const savedPlan = mockDbHelpersInstance.upsertSyncData.mock.calls[0][0]
       .data as { sourceTemplateId?: string }
     expect(savedPlan.sourceTemplateId).toBe(templateFromDb.id)
+  })
+
+  it('populates adopted occurrence segments from template preview metadata', async () => {
+    // Remove canonical data to force preview usage
+    planOccurrencesFromDb = []
+    templateFromDb.metadata = {
+      difficulty: 'beginner',
+      preview: {
+        segments: [
+          {
+            label: 'Preview Warmup',
+            durationMinutes: 10,
+            techniques: ['staccato', 'spiccato'],
+            instructions: 'Light bow strokes',
+            tempoTargets: { targetBpm: 88 },
+          },
+        ],
+      },
+    }
+
+    const req = new Request('http://localhost/api/templates/adopt', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer fake-token',
+      },
+      body: JSON.stringify({ templateId: templateFromDb.id }),
+    })
+
+    const res = await app.fetch(req, createEnv())
+
+    expect(res.status).toBe(200)
+    const payload = (await res.json()) as any
+
+    expect(payload.occurrences[0].segments).toMatchObject([
+      {
+        label: 'Preview Warmup',
+        durationMinutes: 10,
+        techniques: ['staccato', 'spiccato'],
+        instructions: 'Light bow strokes',
+        tempoTargets: { targetBpm: 88 },
+      },
+    ])
+
+    const occurrenceCall = mockDbHelpersInstance.upsertSyncData.mock.calls.find(
+      call => call[0].entityType === 'plan_occurrence'
+    )
+
+    expect(occurrenceCall?.[0].data.segments).toEqual(
+      payload.occurrences[0].segments
+    )
+  })
+
+  it('prefers canonical source plan segments when available', async () => {
+    templateFromDb.metadata = {
+      difficulty: 'beginner',
+      preview: {
+        segments: [
+          {
+            label: 'Preview Warmup',
+            durationMinutes: 10,
+            techniques: ['balance'],
+            instructions: 'Preview instructions',
+            tempoTargets: { targetBpm: 88 },
+          },
+        ],
+      },
+    }
+
+    planOccurrencesFromDb = [
+      { data: JSON.stringify(createPlanOccurrenceRecord()) },
+    ]
+
+    const req = new Request('http://localhost/api/templates/adopt', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer fake-token',
+      },
+      body: JSON.stringify({ templateId: templateFromDb.id }),
+    })
+
+    const res = await app.fetch(req, createEnv())
+
+    expect(res.status).toBe(200)
+    const payload = (await res.json()) as any
+
+    expect(payload.occurrences[0].segments).toMatchObject([
+      {
+        label: 'Canonical Warmup',
+        durationMinutes: 15,
+        instructions: 'Use connected sound',
+        tempoTargets: { targetBpm: 95 },
+        techniques: ['legato'],
+      },
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- derive plan occurrence segments from the original plan or the template preview when adopting a template
- normalize preview segment data so techniques, tempo targets, instructions, and metadata survive the transfer
- add regression tests covering preview-derived segments and canonical plan fallbacks during adoption

## Testing
- `pnpm --filter @mirubato/api test -- templatesHandler`
- `pnpm -r --workspace-concurrency=2 run test:unit -- --watchAll=false`
- `pnpm -r run type-check`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a7e76d5c883218051b4c35f58c5f2)