### PR TITLE
Add data migration for non-cloud users

### DIFF
--- a/frontendv2/src/components/privacy/DataSubjectRights.tsx
+++ b/frontendv2/src/components/privacy/DataSubjectRights.tsx
@@ -361,7 +361,7 @@ export function DataSubjectRights() {
 
       // Import goals
       if (importPreview.goals?.length > 0) {
-        const existingGoals = safeParseJson<Goal[]>(
+        const existingGoals = safeParseJson<LogbookGoal[]>(
           'mirubato:logbook:goals',
           []
         )
@@ -393,7 +393,7 @@ export function DataSubjectRights() {
 
       // Import repertoire goals
       if (importPreview.repertoireGoals?.length > 0) {
-        const existingGoals = safeParseJson<Goal[]>(
+        const existingGoals = safeParseJson<RepertoireGoal[]>(
           'mirubato:repertoire:goals',
           []
         )
@@ -558,7 +558,10 @@ export function DataSubjectRights() {
             'mirubato:logbook:entries',
             []
           )
-          const allGoals = safeParseJson<Goal[]>('mirubato:logbook:goals', [])
+          const allGoals = safeParseJson<LogbookGoal[]>(
+            'mirubato:logbook:goals',
+            []
+          )
 
           await syncApi.push({
             changes: {


### PR DESCRIPTION
- Export now includes ALL user data: logbook entries, goals, repertoire, practice plans, occurrences, templates, custom techniques, metronome settings, and preferences
- Added import functionality to restore data from export files
- For logged-in users: sync from server before export, sync to server after import
- For non-logged-in users: export/import works with local storage only
- Added Data Migration section with clear UI for export/import
- Added version tracking (v2.0) with backwards compatibility for v1.0
- Import uses merge strategy: existing data is preserved, only new items are added
- Updated data overview modal to show comprehensive statistics

close #607 