### PR TITLE
Review i18n dictionary gaps and page layout

### DIFF
--- a/frontendv2/src/components/dictionary/Dictionary.tsx
+++ b/frontendv2/src/components/dictionary/Dictionary.tsx
@@ -192,8 +192,7 @@ const Dictionary: React.FC = () => {
       if (!dictionaryAPI.isServiceAvailable()) {
         setState(prev => ({
           ...prev,
-          error:
-            'Dictionary service is temporarily unavailable. Please try again later.',
+          error: t('toolbox:dictionary.errors.serviceUnavailable'),
           errorDetails: { code: 'SERVICE_UNAVAILABLE' },
           isLoading: false,
         }))
@@ -555,10 +554,9 @@ const Dictionary: React.FC = () => {
                     {t('toolbox:dictionary.aiWillGenerate')}
                   </p>
                 )}
-                {state.error.includes('temporarily unavailable') && (
+                {state.errorDetails?.code === 'SERVICE_UNAVAILABLE' && (
                   <p className="text-sm mt-1 text-amber-600">
-                    The dictionary service will be available again shortly.
-                    Please try again in a few moments.
+                    {t('toolbox:dictionary.errors.serviceUnavailableDetail')}
                   </p>
                 )}
               </div>

--- a/frontendv2/src/i18n/i18n.d.ts
+++ b/frontendv2/src/i18n/i18n.d.ts
@@ -7,6 +7,10 @@ import type errors from '../locales/en/errors.json'
 import type scorebook from '../locales/en/scorebook.json'
 import type toolbox from '../locales/en/toolbox.json'
 import type ui from '../locales/en/ui.json'
+import type about from '../locales/en/about.json'
+import type privacy from '../locales/en/privacy.json'
+import type repertoire from '../locales/en/repertoire.json'
+import type validation from '../locales/en/validation.json'
 
 declare module 'react-i18next' {
   interface CustomTypeOptions {
@@ -20,6 +24,10 @@ declare module 'react-i18next' {
       scorebook: typeof scorebook
       toolbox: typeof toolbox
       ui: typeof ui
+      about: typeof about
+      privacy: typeof privacy
+      repertoire: typeof repertoire
+      validation: typeof validation
     }
   }
 }

--- a/frontendv2/src/locales/de/toolbox.json
+++ b/frontendv2/src/locales/de/toolbox.json
@@ -114,7 +114,9 @@
       "loadFailed": "Fehler beim Laden des Begriffs. Bitte versuchen Sie es erneut.",
       "rateLimitExceeded": "Zu viele Anfragen. Bitte versuchen Sie es später noch einmal.",
       "searchFailed": "Suche fehlgeschlagen. Bitte versuchen Sie es erneut.",
-      "tryAgainIn": "Versuchen Sie es in {{time}} erneut."
+      "tryAgainIn": "Versuchen Sie es in {{time}} erneut.",
+      "serviceUnavailable": "Der Wörterbuchdienst ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.",
+      "serviceUnavailableDetail": "Der Wörterbuchdienst wird in Kürze wieder verfügbar sein. Bitte versuchen Sie es in wenigen Augenblicken erneut."
     },
     "estimatedTime": "Geschätzte Zeit: {{time}}",
     "etymology": "Etymologie",

--- a/frontendv2/src/locales/en/toolbox.json
+++ b/frontendv2/src/locales/en/toolbox.json
@@ -217,7 +217,9 @@
       "searchFailed": "Search failed. Please try again.",
       "loadFailed": "Failed to load term. Please try again.",
       "rateLimitExceeded": "Too many requests. Please try again after a while.",
-      "tryAgainIn": "Try again in {{time}}."
+      "tryAgainIn": "Try again in {{time}}.",
+      "serviceUnavailable": "Dictionary service is temporarily unavailable. Please try again later.",
+      "serviceUnavailableDetail": "The dictionary service will be available again shortly. Please try again in a few moments."
     },
     "searchAllLanguages": "Search in all languages",
     "currentLanguage": "Current language: {{lang}}",

--- a/frontendv2/src/locales/es/toolbox.json
+++ b/frontendv2/src/locales/es/toolbox.json
@@ -114,7 +114,9 @@
       "loadFailed": "Error al cargar el término. Por favor intenta de nuevo.",
       "rateLimitExceeded": "Demasiadas solicitudes. Por favor, inténtelo de nuevo después de un tiempo.",
       "searchFailed": "La búsqueda falló. Por favor intenta de nuevo.",
-      "tryAgainIn": "Inténtelo de nuevo en {{time}}."
+      "tryAgainIn": "Inténtelo de nuevo en {{time}}.",
+      "serviceUnavailable": "El servicio de diccionario no está disponible temporalmente. Por favor, inténtalo más tarde.",
+      "serviceUnavailableDetail": "El servicio de diccionario estará disponible de nuevo en breve. Por favor, inténtalo de nuevo en unos momentos."
     },
     "estimatedTime": "Tiempo estimado: {{time}}",
     "etymology": "Etimología",

--- a/frontendv2/src/locales/fr/toolbox.json
+++ b/frontendv2/src/locales/fr/toolbox.json
@@ -114,7 +114,9 @@
       "loadFailed": "Échec du chargement du terme. Veuillez réessayer.",
       "rateLimitExceeded": "Trop de requêtes. Veuillez réessayer dans un moment.",
       "searchFailed": "La recherche a échoué. Veuillez réessayer.",
-      "tryAgainIn": "Réessayez dans {{time}}."
+      "tryAgainIn": "Réessayez dans {{time}}.",
+      "serviceUnavailable": "Le service de dictionnaire est temporairement indisponible. Veuillez réessayer plus tard.",
+      "serviceUnavailableDetail": "Le service de dictionnaire sera bientôt disponible. Veuillez réessayer dans quelques instants."
     },
     "estimatedTime": "Temps estimé : {{time}}",
     "etymology": "Étymologie",

--- a/frontendv2/src/locales/zh-CN/toolbox.json
+++ b/frontendv2/src/locales/zh-CN/toolbox.json
@@ -114,7 +114,9 @@
       "loadFailed": "加载术语失败。请重试。",
       "rateLimitExceeded": "请求过多。请稍后再试。",
       "searchFailed": "搜索失败。请重试。",
-      "tryAgainIn": "请在{{time}}后重试。"
+      "tryAgainIn": "请在{{time}}后重试。",
+      "serviceUnavailable": "词典服务暂时无法使用。请稍后再试。",
+      "serviceUnavailableDetail": "词典服务将很快恢复。请稍后再试。"
     },
     "estimatedTime": "预计完成时间：{{time}}",
     "etymology": "词源",

--- a/frontendv2/src/locales/zh-TW/toolbox.json
+++ b/frontendv2/src/locales/zh-TW/toolbox.json
@@ -114,7 +114,9 @@
       "loadFailed": "載入術語失敗。請重試。",
       "rateLimitExceeded": "請求過多。請稍後再試。",
       "searchFailed": "搜尋失敗。請重試。",
-      "tryAgainIn": "請在{{time}}後重試。"
+      "tryAgainIn": "請在{{time}}後重試。",
+      "serviceUnavailable": "詞典服務暫時無法使用。請稍後再試。",
+      "serviceUnavailableDetail": "詞典服務將很快恢復。請稍後再試。"
     },
     "estimatedTime": "預計完成時間：{{time}}",
     "etymology": "詞源",


### PR DESCRIPTION
…larations

- Add missing namespaces to i18n.d.ts (about, privacy, repertoire, validation)
- Add serviceUnavailable and serviceUnavailableDetail translation keys to all 6 language files (en, es, fr, de, zh-CN, zh-TW)
- Replace hardcoded error strings in Dictionary.tsx with t() calls