### PR TITLE
fix(deps): override follow-redirects to >=1.16.0 to fix auth header leak

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
 save-exact=true
 ignore-scripts=true
 min-release-age=5
-# TODO: remove after 2026-04-11 when hono 4.12.12 matures past min-release-age (CVE-2026-39408)
-minimum-release-age-exclude[]=hono
+# TODO: remove after 2026-04-19 when follow-redirects 1.16.0 matures past min-release-age (auth header leak on cross-domain redirects)
+minimum-release-age-exclude[]=follow-redirects

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
       "ajv@6": "6.14.0",
       "ajv@8": "8.18.0",
       "rollup": ">=4.59.0",
-      "minimatch": ">=10.2.3"
+      "minimatch": ">=10.2.3",
+      "follow-redirects": ">=1.16.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   ajv@8: 8.18.0
   rollup: '>=4.59.0'
   minimatch: '>=10.2.3'
+  follow-redirects: '>=1.16.0'
 
 importers:
   .:
@@ -5131,10 +5132,10 @@ packages:
         integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
       }
 
-  follow-redirects@1.15.11:
+  follow-redirects@1.16.0:
     resolution:
       {
-        integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==,
+        integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==,
       }
     engines: { node: '>=4.0' }
     peerDependencies:
@@ -9754,7 +9755,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -10368,7 +10369,7 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides` for `follow-redirects >= 1.16.0` to fix auth header leak on cross-domain redirects (custom headers like `X-API-Key` were forwarded to redirect targets)
- Replaces expired hono `min-release-age` exclusion with follow-redirects exclusion (1.16.0 published <5 days ago)
- All tests pass — no regressions

Closes https://github.com/pezware/mirubato/security/dependabot/107

## Test plan

- [x] `pnpm install` resolves `follow-redirects@1.16.0`
- [x] Frontend tests pass (630 passed)
- [x] Dictionary tests pass (229 passed)
- [x] Pre-commit hooks pass (lint-staged + unit tests)