### PR TITLE
Fix for Unused loop iteration variable

### DIFF
--- a/sync-worker/src/syncCoordinator.ts
+++ b/sync-worker/src/syncCoordinator.ts
@@ -1311,7 +1311,7 @@ export class SyncCoordinator implements DurableObject {
   }
 
   private broadcast(data: SyncEvent, excludeClientId?: string): void {
-    for (const [clientId, client] of this.clients) {
+    for (const clientId of this.clients.keys()) {
       if (clientId !== excludeClientId) {
         this.sendToClient(clientId, data)
       }


### PR DESCRIPTION
The best fix is to iterate only over client IDs in `broadcast`, since `client` is not used. This preserves existing functionality while eliminating the unused variable warning.

In `sync-worker/src/syncCoordinator.ts`, update the `broadcast` method loop (around line 1314) from destructuring `[clientId, client]` over `this.clients` to iterating over `this.clients.keys()`. No new imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._